### PR TITLE
PLAT-433 put the thumbnail under the original dir in the thumb path

### DIFF
--- a/src/vignette/media_types.clj
+++ b/src/vignette/media_types.clj
@@ -55,7 +55,6 @@
 
 (declare thumbnail)
 
-; /3/35/100px-100px-resize-arwen.png
 (defn thumbnail-path
   [data]
   (let [image-path (clojure.string/join "/" ((juxt top-dir middle-dir) data))
@@ -66,4 +65,6 @@
 
 (defn thumbnail
   [data]
-  (format "%dpx-%dpx-%s%s-%s" (width data) (height data) (mode data) (query-opts-str data) (original data)))
+  (if (nil? (revision data))
+    (format "%s/%dpx-%dpx-%s%s-%s" (original data) (width data) (height data) (mode data) (query-opts-str data) (original data))
+    (format "%dpx-%dpx-%s%s-%s" (width data) (height data) (mode data) (query-opts-str data) (original data))))

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -30,7 +30,7 @@
 
 (facts :thumbnail-path
        (thumbnail-path archive-map) => "archive/a/ab/12345!boat.jpg/200px-300px-thumbnail-boat.jpg"
-       (thumbnail-path latest-map) => "a/ab/200px-300px-thumbnail-boat.jpg")
+       (thumbnail-path latest-map) => "a/ab/boat.jpg/200px-300px-thumbnail-boat.jpg")
 
 (facts :thumbnail-path-filled
-       (thumbnail-path filled-map) => "a/ab/200px-300px-thumbnail[fill=green]-boat.jpg")
+       (thumbnail-path filled-map) => "a/ab/boat.jpg/200px-300px-thumbnail[fill=green]-boat.jpg")


### PR DESCRIPTION
Put the thumbnail under the original directory on CEPH. This will ensure that if MW moves the directory under the thumb path, that the existing thumbnails will move with it.

For example, the thumbnails are currently being placed under `//bucket/images/thumb/0/0c/*` when they should be placed under `//bucket/images/thumb/0/0c/original.ext/*`.

https://wikia-inc.atlassian.net/browse/PLATFORM-433

/cc @nmonterroso 
