### PR TITLE
correct content-type for webp 

### DIFF
--- a/src/org/apache/tika/mime/custom-mimetypes.xml
+++ b/src/org/apache/tika/mime/custom-mimetypes.xml
@@ -1,0 +1,12 @@
+<mime-info>
+    <mime-type type="image/webp">
+        <!-- container spec https://developers.google.com/speed/webp/docs/riff_container -->
+        <acronym>WEBP</acronym>
+        <tika:link>http://en.wikipedia.org/wiki/WebP</tika:link>
+        <magic priority="50">
+            <match value="RIFF....WEBP" type="string" offset="0"
+                   mask="0xFFFFFFFF00000000FFFFFFFF"/>
+        </magic>
+        <glob pattern="*.webp"/>
+    </mime-type>
+</mime-info>


### PR DESCRIPTION
@drsnyder 
Adding custom-mimetypes.xml in the correct place for Tika to read it ([link](http://tika.apache.org/1.0/parser_guide.html#Add_your_MIME-Type)). I'll also submit a patch to them to add to their core mimetypes xml. [JIRA](https://wikia-inc.atlassian.net/browse/PLATFORM-518) so it doesn't get lost/forgotten.

Modeled after other RIFF-spec mime-type checkers (search for RIFF....WAVE [here](http://svn.apache.org/repos/asf/tika/trunk/tika-core/src/main/resources/org/apache/tika/mime/tika-mimetypes.xml))
