### PR TITLE
add path-prefix get param, and place it before language if present

### DIFF
--- a/src/vignette/media_types.clj
+++ b/src/vignette/media_types.clj
@@ -14,10 +14,10 @@
   (:image-type object-map))
 
 (defmethod image-type->path-prefix "images" [object-map]
-  (let [prefix (:image-type object-map)]
-    (if-let [lang (query-opt object-map :lang)]
-      (str lang "/" prefix)
-      prefix)))
+  (let [path-prefix (query-opt object-map :path-prefix)
+        lang (query-opt object-map :lang)
+        prefix (:image-type object-map)]
+    (clojure.string/join "/" (filter not-empty [path-prefix lang prefix]))))
 
 (defmethod image-type->path-prefix :default [object-map]
   (throw+ {:type ::error :message (str "unsupported image-type "

--- a/src/vignette/util/query_options.clj
+++ b/src/vignette/util/query_options.clj
@@ -3,7 +3,8 @@
 ; regex of valid inputs for query args
 (def query-opts-map {:fill #"^#[a-g0-9]+$|^\w+$"
                      :format #"^\w+$"
-                     :lang #"^\w+$"})
+                     :lang #"^\w+$"
+                     :path-prefix #"[\w\/]+"})
 
 (defn extract-query-opts
   [request]
@@ -29,7 +30,7 @@
   (if-let [options (query-opts data)]
     (str "["
          (clojure.string/join "," (sort (map (fn [[k v]]
-                                               (str (name k) "=" v))
+                                               (str (name k) "=" (clojure.string/replace v "/" "-")))
                                              options)))
          "]")
     ""))

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -27,6 +27,9 @@
 
 (def lang-map (assoc latest-map :options {:lang "es"}))
 
+(def prefix-path-map (assoc latest-map :options {:lang "de"
+                                                 :path-prefix "pokemanshop/zh"}))
+
 (def lang-original-map (assoc original-map :options {:lang "es"}))
 
 (facts :revision
@@ -51,3 +54,6 @@
 (facts :lang-path
        (thumbnail-path lang-map) => "es/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail[lang=es]-boat.jpg"
        (original-path lang-original-map) => "es/images/2/2a/Injustice_Vol2_1.jpg")
+
+(facts :prefix-path
+       (thumbnail-path prefix-path-map) => "pokemanshop/zh/de/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail[lang=de,path-prefix=pokemanshop-zh]-boat.jpg")


### PR DESCRIPTION
@drsnyder 
changes on vignette side to account for new path-prefix get param. this will replace the lang get parameter (prefixes are not always languages), but leaving that get parameter in for now until the path-prefix code makes it to production on the mediawiki side and all parser caches expire.

See https://github.com/Wikia/app/pull/5130 for changes in PHP client
