### PR TITLE
Add support for ?replace=true query option.

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -21,6 +21,7 @@
             [vignette.util.filesystem :as fs]
             [vignette.util.integration :as itg]
             [vignette.util.thumbnail :as u]
+            [vignette.util.query-options :as q]
             [wikia.common.logger :as log])
   (:use [environ.core]))
 

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -59,7 +59,8 @@
 
 (defn get-or-generate-thumbnail
   [system thumb-map]
-  (if-let [thumb (get-thumbnail (store system) thumb-map)]
+  (if-let [thumb (and (not (q/query-opt thumb-map :replace))
+                      (get-thumbnail (store system) thumb-map))]
     thumb
     (when-let [thumb (generate-thumbnail system thumb-map)]
       (background-save-thumbnail (store system) thumb thumb-map)

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -51,9 +51,14 @@
 (facts :thumbnail-path-filled
        (thumbnail-path filled-map) => "images/thumb/a/ab/boat.jpg/200px-300px-thumbnail[fill=green]-boat.jpg")
 
+; Neither of these should modify the resulting filename since they don't have sideffects
 (facts :lang-path
-       (thumbnail-path lang-map) => "es/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail[lang=es]-boat.jpg"
+       (thumbnail-path lang-map) => "es/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail-boat.jpg"
        (original-path lang-original-map) => "es/images/2/2a/Injustice_Vol2_1.jpg")
 
 (facts :prefix-path
-       (thumbnail-path prefix-path-map) => "pokemanshop/zh/de/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail[lang=de,path-prefix=pokemanshop-zh]-boat.jpg")
+       (thumbnail-path prefix-path-map) => "pokemanshop/zh/de/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail-boat.jpg")
+
+(facts :fill-path
+       (thumbnail-path (assoc-in lang-map [:options :fill] "purple")) => "es/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail[fill=purple]-boat.jpg"
+       (original-path lang-original-map) => "es/images/2/2a/Injustice_Vol2_1.jpg")

--- a/test/vignette/util/query_options_test.clj
+++ b/test/vignette/util/query_options_test.clj
@@ -12,7 +12,10 @@
                 :height "300"
                 :options {}})
 
-(def thumb-option-map (assoc thumb-map :options {:fill "purple"}))
+(def thumb-option-map (assoc thumb-map :options {:fill "purple" :lang "zh" :replace true}))
+
+(facts :create-query-opt
+  (create-query-opt #"\w+") => (contains {:regex #"\w+" :side-effects true}))
 
 (facts :request-options
        (extract-query-opts {:query-params {"fill" "blue"
@@ -22,7 +25,7 @@
        (extract-query-opts {:query-params {"format" "ls -l"}}) => {})
 
 (facts :query-opts
-       (query-opts thumb-option-map) => {:fill "purple"}
+       (query-opts thumb-option-map) => {:fill "purple" :lang "zh" :replace true}
        (query-opts thumb-map) => nil)
 
 (facts :query-opt
@@ -32,7 +35,7 @@
 
 (facts :query-opts-str
        (query-opts-str thumb-map) => ""
-       (query-opts-str thumb-option-map) "[fill=purple]")
+       (query-opts-str thumb-option-map) => "[fill=purple]")
 
 (facts :query-opts->thumb-args
        (query-opts->thumb-args thumb-map) => []

--- a/test/vignette/util/thumbnail_test.clj
+++ b/test/vignette/util/thumbnail_test.clj
@@ -73,7 +73,15 @@
          (provided
            (store ..system..) => ..store..
            (get-thumbnail ..store.. image-dne) => false
-           (get-original ..store.. image-dne) => false)))
+           (get-original ..store.. image-dne) => false))
+
+       ; fall through when :replace is set
+       (let [option-map (assoc-in beach-map [:options :replace] "true")]
+         (get-or-generate-thumbnail ..system.. option-map) => ..new-thumb..
+         (provided
+           (store ..system..) => ..store..
+           (generate-thumbnail ..system.. option-map) => ..new-thumb..
+           (background-save-thumbnail ..store.. ..new-thumb.. option-map) => true)))
 
 (facts :route-map->thumb-args
        (route-map->thumb-args beach-map) => (contains ["--height" "100" "--width" "100"


### PR DESCRIPTION
Add support for ?replace=true query option. This option will bypass the check to see if the thumbnail exists in CEPH, generate the thumbnail, then store it back causing an existing thumbnail to be replaced.

This will be useful for cases where a thumbnail is improperly generated or broken.

/cc @nmonterroso 
