### PR TITLE
Add env vars for setting http-kit server params

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Below is a list of environment variables that will affect the vignette runtime.
  * `VIGNETTE_TEMP_FILE_LOCATION`  temporary file location. This is used for thumbnail generation. [/tmp/vignette]
  * `VIGNETTE_THUMBNAIL_BIN`       path to the thumbnail script [/usr/local/bin/thumbnail, bin/thumbnail]
  * `VIGNETTE_INTEGRATION_ROOT`    path to use for integration testing files [/tmp/integration]
+ * `VIGNETTE_SERVER_THREADS`      number of threads to allocate for http-kit [4]
+ * `VIGNETTE_SERVER_QUEUE_SIZE`   queue size to allocate for http-kit [20000]
  * `IMAGEMAGICK_BASE`             path to the root of the ImageMagick installation [/usr/local]
  * `GETOPT`                       when running on osx, install gnu-getopt using brew. see bin/thumbnail
  * `CONVERT_CONSTRAINTS`          universal options to pass to ImageMagick. see bin/thumbnail

--- a/src/vignette/system.clj
+++ b/src/vignette/system.clj
@@ -5,6 +5,9 @@
             [vignette.protocols :refer :all]
             [vignette.server :as s]))
 
+(def default-threads 4)
+(def default-queue-size 20000)
+
 (defrecord VignetteSystem [state]
   SystemAPI
   (store [this]
@@ -14,7 +17,9 @@
            (fn [_]
              (run-server
                (#'app-routes this)
-               {:port port}))))
+               {:port port
+                :thread (Integer. (env :vignette-server-threads default-threads))
+                :queue-size (Integer. (env :vignette-server-queue-size default-queue-size))}))))
   (stop [this]
     (when-let [stop-fn @(:running (:state this))]
       (stop-fn))))


### PR DESCRIPTION
Add environment variables for :thread and :queue-size via VIGNETTE_SERVER_THREADS and VIGNETTE_SERVER_QUEUE_SIZE respectively. This will allow us to toggle the respective allocations via the environment.

/cc @nmonterroso 
