### PR TITLE
send Connection: close header

### DIFF
--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -106,7 +106,8 @@
           (header "Varnish-Logs" "vignette")
           (header "X-Served-By" hostname)
           (header "X-Cache" "ORIGIN")
-          (header "X-Cache-Hits" "ORIGIN")))))
+          (header "X-Cache-Hits" "ORIGIN")
+          (header "Connection" "close")))))
 
 (defn route-params->image-type
   [route-params]


### PR DESCRIPTION
@drsnyder 
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

> HTTP/1.1 defines the "close" connection option for the sender to signal that the connection will be closed after completion of the response. For example,
> 
> ```
>   Connection: close
> ```
> 
> in either the request or the response header fields indicates that the connection SHOULD NOT be considered `persistent' (section 8.1) after the current request/response is complete.
> 
> HTTP/1.1 applications that do not support persistent connections MUST include the "close" connection option in every message.
