### PR TITLE
Dimension keyword name

### DIFF
--- a/src/vignette/media_types.clj
+++ b/src/vignette/media_types.clj
@@ -86,7 +86,9 @@
 
 (defn width
   [data]
-  (let [width (:width data)
+  (let [width (if (keyword? (:width data))
+                (name (:width data))
+                (:width data))
         x-offset (:x-offset data)
         window-width (:window-width data)]
     (window-format width x-offset window-width)))


### PR DESCRIPTION
@drsnyder 
don't let colons get into the filename in CEPH. Some clients (Boto in Python) have trouble reading these files.
