### PR TITLE
calculate density for svg thumbs

### DIFF
--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -363,6 +363,8 @@ function is_animated() {
 	fi
 }
 
+# set background = none to preserve original backgrounds for svgs, and calculate density for
+# scaling svg (http://www.imagemagick.org/discourse-server/viewtopic.php?t=11168#p37647)
 function svg_preoptions() {
 	local default_density=72
 	local orig_height=$($IDENTIFY -format "%h\n" "$IN" | head -1)


### PR DESCRIPTION
@drsnyder 
https://wikia-inc.atlassian.net/browse/PLATFORM-608

Calculate density so we can scale svgs up without causing blurry images. See current version of [vignette](http://vignette.wikia.nocookie.net/bloonsconception/images/2/25/Zoomtest.svg/revision/latest/thumbnail/width/200/height/200?replace=true) generated thumb vs [legacy](http://images.wikia.com/bloonsconception/images/thumb/2/25/Zoomtest.svg/200px-Zoomtest.svg) generated thumb.
