### PR TITLE
Preserve transparency when window-crop is used

### DIFF
--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -317,6 +317,9 @@ function thumb_params() {
 			fi
 			;;
 		"window-crop")
+			# When PNGs are used we need to make sure the source image's transparency
+			# is preserved. See http://www.imagemagick.org/Usage/crop/#border and the
+			# 'Border and Alpha Composition' section regarding regarding transparency.
 			THUMB_PARAMS="${QUALITY} \( ${IN} -compose Copy -extent ${WINDOW_WIDTH}x${WINDOW_HEIGHT}+${X_OFFSET}+${Y_OFFSET}! -thumbnail ${WINDOW_WIDTH}x${WINDOW_HEIGHT}! \)"
 			THUMB_PARAMS="${THUMB_PARAMS} \( -thumbnail ${WIDTH} \)"
 			IN="" # is now part of THUMB_PARAMS


### PR DESCRIPTION
Use `-compose Copy` to preserve transparency when window-crop is used on PNG's. This is only being added to the `window-crop` mode and not also `window-crop-fixed` because the latter doesn't appear to be used as frequently and it is typically coupled with a `--fill` option which might complicate things further.

https://wikia-inc.atlassian.net/browse/PLATFORM-604

/cc @nmonterroso 
