### PR TITLE
PLATFORM-667 directly addressible originals

### DIFF
--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -18,13 +18,6 @@
             [vignette.util.regex :refer :all]
             [vignette.util.thumbnail :as u]))
 
-(def revisionless-original-route
-  (route-compile "/:wikia:image-type/:top-dir/:middle-dir/:original"
-                 {:wikia wikia-regex
-                  :image-type image-type-regex
-                  :top-dir top-dir-regex
-                  :middle-dir middle-dir-regex
-                  :original original-regex}))
 
 (def original-route
   (route-compile "/:wikia:image-type/:top-dir/:middle-dir/:original/revision/:revision"
@@ -110,9 +103,6 @@
         (GET thumbnail-route
              request
              (image-request-handler system :thumbnail request))
-        (GET revisionless-original-route
-             request
-             (image-request-handler system :original request))
         (GET original-route
              request
              (image-request-handler system :original request))

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -18,7 +18,6 @@
             [vignette.util.regex :refer :all]
             [vignette.util.thumbnail :as u]))
 
-
 (def original-route
   (route-compile "/:wikia:image-type/:top-dir/:middle-dir/:original/revision/:revision"
                  {:wikia wikia-regex

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -5,17 +5,50 @@
             [ring.mock.request :refer :all]
             [vignette.http.routes :refer :all]
             [vignette.protocols :refer :all]
+            [vignette.util.image-response :refer :all]
+            [vignette.storage.core :refer :all]
             [vignette.storage.local :as ls]
             [vignette.storage.protocols :as sp]
             [vignette.util.image-response :as ir]
             [vignette.util.thumbnail :as u])
   (:import java.io.FileNotFoundException))
 
+(facts :image-request-handler
+  (image-request-handler {} :foo {}) => (throws IllegalArgumentException)
 
-; TODO:
-;  - test image-request-handler
-;  - test handle-thumbnail
-;  - test handle-original
+  (image-request-handler ..system.. :thumbnail ..request..) => ..response..
+  (provided
+    (image-params ..request.. :thumbnail) => ..params..
+    (handle-thumbnail ..system.. ..params..) => ..response..)
+
+  (image-request-handler ..system.. :original ..request..) => ..response..
+  (provided
+    (image-params ..request.. :original) => ..params..
+    (handle-original ..system.. ..params..) => ..response..))
+
+(facts :handle-thumbnail
+  (handle-thumbnail ..system.. ..params..) => ..response..
+  (provided
+    (u/get-or-generate-thumbnail ..system.. ..params..) => ..thumb..
+    (create-image-response ..thumb..) => ..response..)
+
+  (handle-thumbnail ..system.. ..params..) => ..error..
+  (provided
+    (u/get-or-generate-thumbnail ..system.. ..params..) => nil
+    (error-response 404 ..params..) => ..error..))
+
+(facts :handle-original
+  (handle-original ..system.. ..params..) => ..response..
+  (provided
+    (store ..system..) => ..store..
+    (sp/get-original ..store.. ..params..) => ..original..
+    (create-image-response ..original..) => ..response..)
+
+  (handle-original ..system.. ..params..) => ..error..
+  (provided
+    (store ..system..) => ..store..
+    (sp/get-original ..store.. ..params..) => nil
+    (error-response 404 ..params..) => ..error..))
 
 (facts :original-route
   (route-matches original-route (request :get "/swift/v1")) => falsey

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -152,7 +152,6 @@
       (store ..system..) => ..store..
       (sp/get-original ..store.. route-params) =throws=> (NullPointerException.))))
 
-
 (facts :window-crop-route
        (route-matches window-crop-route
                       (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/103")) =>

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -11,6 +11,12 @@
             [vignette.util.thumbnail :as u])
   (:import java.io.FileNotFoundException))
 
+
+; TODO:
+;  - test image-request-handler
+;  - test handle-thumbnail
+;  - test handle-original
+
 (facts :original-route
   (route-matches original-route (request :get "/swift/v1")) => falsey
   (route-matches
@@ -112,6 +118,26 @@
     (provided
       (store ..system..) => ..store..
       (sp/get-original ..store.. route-params) =throws=> (NullPointerException.))))
+
+(facts :app-routes-revisionless-original
+
+  (let [route-params {:request-type :original
+                      :image-type "images"
+                      :original "ropes.jpg"
+                      :middle-dir "35"
+                      :top-dir "3"
+                      :wikia "lotr"
+                      :options {}} ]
+    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg")) => (contains {:status 200})
+    (provided
+     (store ..system..) => ..store..
+     (sp/get-original ..store.. (just route-params)) => (ls/create-stored-object (io/file "image-samples/ropes.jpg")))
+
+    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg")) => (contains {:status 404})
+    (provided
+     (store ..system..) => ..store..
+     (sp/get-original ..store.. route-params) => nil)))
+
 
 (facts :window-crop-route
        (route-matches window-crop-route

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -152,25 +152,6 @@
       (store ..system..) => ..store..
       (sp/get-original ..store.. route-params) =throws=> (NullPointerException.))))
 
-(facts :app-routes-revisionless-original
-
-  (let [route-params {:request-type :original
-                      :image-type "images"
-                      :original "ropes.jpg"
-                      :middle-dir "35"
-                      :top-dir "3"
-                      :wikia "lotr"
-                      :options {}} ]
-    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg")) => (contains {:status 200})
-    (provided
-     (store ..system..) => ..store..
-     (sp/get-original ..store.. (just route-params)) => (ls/create-stored-object (io/file "image-samples/ropes.jpg")))
-
-    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg")) => (contains {:status 404})
-    (provided
-     (store ..system..) => ..store..
-     (sp/get-original ..store.. route-params) => nil)))
-
 
 (facts :window-crop-route
        (route-matches window-crop-route


### PR DESCRIPTION
It was originally believed that the issue with [favicons](https://wikia-inc.atlassian.net/browse/PLATFORM-667) was the result of the `/revision/latest...` at the end of the favicon link tag. This appears [not to be the case](http://www.google.com/s2/favicons?domain=thelongdark.wikia.com) since [other vignette enabled sites](http://despicableme.wikia.com/wiki/Despicable_Me_Wiki) do not appear to have the same issue.

This PR makes originals directly addressable via `/images/top/middle/original.ext` (drops `/revision/latests`). It also provides some refactoring of `routes` to removed duplicated logic and more tests.

https://wikia-inc.atlassian.net/browse/PLATFORM-667

/cc @nmonterroso 