### PR TITLE
Set default max-retries to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Below is a list of environment variables that will affect the vignette runtime.
  * `STORAGE_SECRET_KEY`           S3 secret key
  * `STORAGE_ENDPOINT`             S3 HTTP endpoint
  * `STORAGE_PROXY`                S3 Proxy
+ * `STORAGE_MAX_RETRIES`          S3 max error retry count; defaults to 0
  * `STORAGE_PROXY_PORT`           S3 Proxy port
  * `VIGNETTE_TEMP_FILE_LOCATION`  temporary file location. This is used for thumbnail generation. [/tmp/vignette]
  * `VIGNETTE_THUMBNAIL_BIN`       path to the thumbnail script [/usr/local/bin/thumbnail, bin/thumbnail]

--- a/src/vignette/storage/s3.clj
+++ b/src/vignette/storage/s3.clj
@@ -18,7 +18,7 @@
 ;;;; seconds for the exception to bubble up. --drsnyder
 
 (comment
-  (def storage-creds {:max-reties 0
+  (def storage-creds {:max-retries 0
                       :socket-timeout 20 ; one of these should timeout most of the time
                       :conn-timeout 20
                       :access-key "..."
@@ -44,12 +44,14 @@
 (def default-storage-connection-timeout 100)
 (def default-storage-get-socket-timeout 500)
 (def default-storage-put-socket-timeout 10000)
+(def default-storage-max-retries 0)
 
 (declare create-stored-object)
 
 (def storage-creds (let [creds {:access-key  (env :storage-access-key)
                                 :secret-key  (env :storage-secret-key)
                                 :endpoint    (env :storage-endpoint)
+                                :max-retries (env :storage-max-retries default-storage-max-retries)
                                 :proxy {:host (env :storage-proxy)}}]
                      (if-let [port (env :storage-proxy-port)]
                        (assoc-in creds [:proxy :port] (Integer/parseInt port))


### PR DESCRIPTION
If we have a failed HTTP request into CEPH don't bother retrying. There appears to be an issue in the S3 client that introduces additional latency when the error retry count is > 0. Under load, this can backup vignette and connections on the borders.

https://wikia-inc.atlassian.net/browse/PLATFORM-690

/cc @nmonterroso @frankfarmer 