### PR TITLE
Fix integration setup by separating out the transfer! method into a new protocol

### DIFF
--- a/src/vignette/storage/local.clj
+++ b/src/vignette/storage/local.clj
@@ -35,13 +35,6 @@
   (list-buckets [this])
   (list-objects [this bucket]))
 
-(extend java.io.File
-  TransferableProtocol
-  {:transfer! (fn [from to]
-                (io/copy from
-                         (io/file to))
-                (file-exists? to))})
-
 (defrecord LocalStoredObject [file stream-close-callbacks]
   StoredObjectProtocol
   (file-stream [this]
@@ -57,8 +50,6 @@
         (close []
           (proxy-super close)
           (doall (map #(% stored-object) (:stream-close-callbacks stored-object)))))))
-
-  TransferableProtocol
   (transfer! [this to]
     (io/copy (file-stream this)
              (io/file to))

--- a/src/vignette/storage/protocols.clj
+++ b/src/vignette/storage/protocols.clj
@@ -18,5 +18,7 @@
   (file-stream [this])
   (content-length [this])
   (content-type [this])
-  (transfer! [this to])
   (->response-object [this]))
+
+(defprotocol TransferableProtocol
+  (transfer! [this to]))

--- a/src/vignette/storage/protocols.clj
+++ b/src/vignette/storage/protocols.clj
@@ -18,7 +18,5 @@
   (file-stream [this])
   (content-length [this])
   (content-type [this])
+  (transfer! [this to])
   (->response-object [this]))
-
-(defprotocol TransferableProtocol
-  (transfer! [this to]))

--- a/src/vignette/storage/s3.clj
+++ b/src/vignette/storage/s3.clj
@@ -114,8 +114,6 @@
     (:content-type (:meta-data this)))
   (->response-object [this]
     (file-stream this))
-
-  TransferableProtocol
   (transfer! [this to]
     (with-open [in-stream (io/input-stream (file-stream this))
                 out-stream (io/output-stream to)]

--- a/src/vignette/storage/s3.clj
+++ b/src/vignette/storage/s3.clj
@@ -112,13 +112,15 @@
     (:content-length (:meta-data this)))
   (content-type [this]
     (:content-type (:meta-data this)))
+  (->response-object [this]
+    (file-stream this))
+
+  TransferableProtocol
   (transfer! [this to]
     (with-open [in-stream (io/input-stream (file-stream this))
                 out-stream (io/output-stream to)]
       (io/copy in-stream out-stream))
-    (file-exists? to))
-  (->response-object [this]
-    (file-stream this)))
+    (file-exists? to)))
 
 (defn create-s3-storage-system
   [creds]

--- a/src/vignette/util/integration.clj
+++ b/src/vignette/util/integration.clj
@@ -3,7 +3,7 @@
             [clojure.java.io :as io]
             [clojure.java.shell :refer [sh]]
             [vignette.storage.core :refer [create-image-storage]]
-            [vignette.storage.local :refer [create-local-storage-system]]
+            [vignette.storage.local :refer [create-local-storage-system create-stored-object]]
             [vignette.storage.protocols :refer :all]
             [vignette.storage.s3 :as vs3])
   (:use [environ.core]))
@@ -27,7 +27,7 @@
   ([path]
    (let [local-store (create-local-storage-system path)
          image-store (create-image-storage local-store)]
-    (every? true? (map #(save-original image-store (:file-on-disk %) %)
+    (every? true? (map #(save-original image-store (create-stored-object (:file-on-disk %)) %)
                        (get-sample-image-maps)))))
   ([]
    (create-integration-env integration-path)))

--- a/src/vignette/util/integration.clj
+++ b/src/vignette/util/integration.clj
@@ -13,6 +13,7 @@
 (def default-map {:wikia "bucket"
                   :top-dir "a"
                   :middle-dir "ab"
+                  :image-type "images"
                   :request-type :original})
 
 (defn get-sample-image-maps

--- a/test/vignette/util/integration_test.clj
+++ b/test/vignette/util/integration_test.clj
@@ -10,7 +10,7 @@
             [vignette.util.integration :as i]))
 
 (facts :get-sample-image-maps
-  (first (i/get-sample-image-maps)) => (contains {:top-dir "a", :wikia "bucket", :image-type "images", :middle-dir "ab", :original "beach.jpg", :request-type :original}))
+  (keys (first (i/get-sample-image-maps))) => (contains #{:file-on-disk :top-dir :wikia :image-type :middle-dir :original :request-type}))
 
 (facts :create-integration-env
   (let [local-store (create-local-storage-system i/integration-path)

--- a/test/vignette/util/integration_test.clj
+++ b/test/vignette/util/integration_test.clj
@@ -1,0 +1,19 @@
+(ns vignette.util.integration-test
+  (:require [clojure.java.io :as io]
+            [midje.sweet :refer :all]
+            [vignette.http.routes :refer :all]
+            [vignette.protocols :refer :all]
+            [vignette.storage.core :refer [create-image-storage]]
+            [vignette.storage.local :refer [create-local-storage-system]]
+            [vignette.storage.protocols :refer :all]
+            [vignette.util.filesystem :refer :all]
+            [vignette.util.integration :as i]))
+
+(facts :get-sample-image-maps
+  (first (i/get-sample-image-maps)) => (contains {:top-dir "a", :wikia "bucket", :image-type "images", :middle-dir "ab", :original "beach.jpg", :request-type :original}))
+
+(facts :create-integration-env
+  (let [local-store (create-local-storage-system i/integration-path)
+        image-store (create-image-storage local-store)]
+    (i/create-integration-env i/integration-path) => truthy
+    (get-original image-store (first (i/get-sample-image-maps))) => truthy))


### PR DESCRIPTION
This PR fixes the integration setup. A while back I added `(i/create-integration-env)` which will create a local integration data directory that could be used with `vignette.storage.local`. I must have broken it back when we moved the `transfer!` logic from a multi-method into a protocol.

This PR moves the `transfer!` method into a separate protocol called `TransferableProtocol ` so that the native `java.io.File` abstraction can be `extend`ed to support the `transfer!` method natively. This is the [expression problem](http://www.ibm.com/developerworks/library/j-clojure-protocols/) which clojure provides a nice solution to. Clojure, I :heart: you.

/cc @nmonterroso @owend just for the love