### PR TITLE
add Content-Disposition header for images

### DIFF
--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -110,7 +110,7 @@
                    image-params (assoc route-params :thumbnail-mode "scale-to-width"
                                                     :height :auto)]
                (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
-                 (create-image-response thumb)
+                 (create-image-response thumb image-params)
                  (error-response 404 image-params))))
         (GET window-crop-route
              request
@@ -118,26 +118,26 @@
                    image-params (assoc route-params :thumbnail-mode "window-crop"
                                                     :height :auto)]
                (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
-                 (create-image-response thumb)
+                 (create-image-response thumb image-params)
                  (error-response 404 image-params))))
         (GET window-crop-fixed-route
              request
              (let [route-params (image-params request :thumbnail)
                    image-params (assoc route-params :thumbnail-mode "window-crop-fixed")]
                (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
-                 (create-image-response thumb)
+                 (create-image-response thumb image-params)
                  (error-response 404 image-params))))
         (GET thumbnail-route
              request
              (let [image-params (image-params request :thumbnail)]
                (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
-                 (create-image-response thumb)
+                 (create-image-response thumb image-params)
                  (error-response 404 image-params))))
         (GET original-route
              request
              (let [image-params (image-params request :original)]
                (if-let [file (original-request->file request system image-params)]
-                 (create-image-response file)
+                 (create-image-response file image-params)
                  (error-response 404 image-params))))
 
         ; legacy routes
@@ -145,13 +145,13 @@
              request
              (let [image-params (alr/route->thumb-map (:route-params request))]
                (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
-                   (create-image-response thumb)
+                   (create-image-response thumb image-params)
                    (error-response 404 image-params))))
         (GET alr/original-route
              request
              (let [image-params (alr/route->original-map (:route-params request))]
                (if-let [file (original-request->file request system image-params)]
-                 (create-image-response file)
+                 (create-image-response file image-params)
                  (error-response 404 image-params))))
         (GET "/ping" [] "pong")
         (files "/static/")

--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -29,7 +29,13 @@
    (error-response code nil)))
 
 (defn create-image-response
-  [image]
-  (-> (response (->response-object image))
-      (header "Content-Type" (content-type image))
-      (header "Content-Length" (content-length image))))
+  ([image image-map]
+    (-> (response (->response-object image))
+        (header "Content-Type" (content-type image))
+        (header "Content-Length" (content-length image))
+        (cond->
+          (:original image-map) (header "Content-Disposition"
+                                        (str "inline; filename=\""(:original image-map)"\";"
+                                             "filename*=utf=8' '\""(:original image-map)"\";")))))
+  ([image]
+    (create-image-response image nil)))

--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -35,7 +35,8 @@
         (header "Content-Length" (content-length image))
         (cond->
           (:original image-map) (header "Content-Disposition"
-                                        (str "inline; filename=\""(:original image-map)"\";"
-                                             "filename*=utf=8' '\""(:original image-map)"\";")))))
+                                        (format "inline; filename=\"%s\"; filename*=utf-8' '%s"
+                                                (:original image-map)
+                                                (:original image-map))))))
   ([image]
     (create-image-response image nil)))


### PR DESCRIPTION
@drsnyder 
https://wikia-inc.atlassian.net/browse/PLATFORM-632

Add a `Content-Disposition` header so "save as..." dialogs have a hint of the filename to use when saving. Tested in Chrome and Firefox and works as expected. Note that the `filename=` part is kept for user agents that don't support [RFC 5987](https://tools.ietf.org/html/rfc5987), which in my testing it seems that Firefox does not.