### PR TITLE
remove filename*= portion of Content-Disposition header

### DIFF
--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -35,8 +35,7 @@
         (header "Content-Length" (content-length image))
         (cond->
           (:original image-map) (header "Content-Disposition"
-                                        (format "inline; filename=\"%s\"; filename*=utf-8' '%s"
-                                                (:original image-map)
+                                        (format "inline; filename=\"%s\""
                                                 (:original image-map))))))
   ([image]
     (create-image-response image nil)))


### PR DESCRIPTION
@drsnyder 
https://wikia-inc.atlassian.net/browse/PLATFORM-751

I think special characters were causing the `filename*=UTF-8' '%s` to break vignette requests in Chrome. Looks like Chrome respects utf-8 characters in `filename="%s"`.