### PR TITLE
MAIN-3622 Timeline legacy support

### DIFF
--- a/src/vignette/api/legacy/routes.clj
+++ b/src/vignette/api/legacy/routes.clj
@@ -41,6 +41,13 @@
                   :middle-dir middle-dir-regex
                   :original original-regex}))
 
+(def timeline-route
+  (route-compile "/:wikia:path-prefix/:image-type/timeline/:original"
+                 {:wikia wikia-regex
+                  :path-prefix path-prefix-regex
+                  :image-type #"images"
+                  :original original-regex}))
+
 (defn route->thumb-map
   [route-params]
   ; order is important! mostly due to the different options changing :thumbnail-mode
@@ -60,6 +67,13 @@
                 (route->revision)
                 (route->options))]
     map))
+
+(defn route->timeline-map
+  [route-params]
+  (-> route-params
+      (assoc :request-type :original)
+      (assoc :top-dir "timeline")
+      (route->options)))
 
 (defn route->revision
   [map]

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -153,6 +153,12 @@
                (if-let [file (original-request->file request system image-params)]
                  (create-image-response file image-params)
                  (error-response 404 image-params))))
+        (GET alr/timeline-route
+             request
+             (let [image-params (alr/route->timeline-map (:route-params request))]
+               (if-let [file (original-request->file request system image-params)]
+                 (create-image-response file image-params)
+                 (error-response 404 image-params))))
         (GET "/ping" [] "pong")
         (files "/static/")
         (not-found "Unrecognized request path!\n"))

--- a/src/vignette/media_types.clj
+++ b/src/vignette/media_types.clj
@@ -53,6 +53,14 @@
   (:original data))
 
 (defn original-path
+  "From a request map, generate a URI for an original image. These typically
+  take the form of one of the following:
+
+  /bucket/images/a/ab/original.ext
+  /bucket/avatars/a/ab/original.ext
+  /bucket/lang/images/a/ab/original.ext
+  /bucket/lang/images/timeline/original.ext
+  "
   [data]
   (let [prefix (image-type->path-prefix data)
         image-path (clojure.string/join "/" (filter not-empty ((juxt top-dir middle-dir) data)))

--- a/src/vignette/media_types.clj
+++ b/src/vignette/media_types.clj
@@ -55,7 +55,7 @@
 (defn original-path
   [data]
   (let [prefix (image-type->path-prefix data)
-        image-path (clojure.string/join "/" ((juxt top-dir middle-dir) data))
+        image-path (clojure.string/join "/" (filter not-empty ((juxt top-dir middle-dir) data)))
         filename (revision-filename data)]
     (if (nil? (revision data))
       (clojure.string/join "/" [prefix image-path filename])

--- a/test/vignette/api/legacy/routes_test.clj
+++ b/test/vignette/api/legacy/routes_test.clj
@@ -147,3 +147,15 @@
          (:original map) => "Flag_of_Europe.svg"
          (:revision map) => "latest"
          (:path-prefix (:options map)) => "fr"))
+
+(facts :timeline-route
+  (let [map (alr/route->timeline-map
+              (route-matches alr/timeline-route
+                             (request :get "/television/es/images/timeline/bbe457792492f1b89f21a45aa6ca6088.png")))]
+    (:request-type map) => :original
+    (:top-dir map) => "timeline"
+    (:middle-dir map) => nil
+    (:wikia map) => "television"
+    (:path-prefix (:options map)) => "es"
+    (:original map) => "bbe457792492f1b89f21a45aa6ca6088.png"
+    (:image-type map) => "images"))

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -32,6 +32,15 @@
 
 (def lang-original-map (assoc original-map :options {:lang "es"}))
 
+
+(def timeline-file "bbe457792492f1b89f21a45aa6ca6088.jpg")
+(def timeline-map {:wikia "television"
+                   :image-type "images"
+                   :top-dir "timeline"
+                   :original timeline-file
+                   :revision "latest"
+                   :options {:path-prefix "es"}})
+
 (facts :revision
        (revision archive-map) => "12345"
        (revision latest-map) => nil)
@@ -62,3 +71,6 @@
 (facts :fill-path
        (thumbnail-path (assoc-in lang-map [:options :fill] "purple")) => "es/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail[fill=purple]-boat.jpg"
        (original-path lang-original-map) => "es/images/2/2a/Injustice_Vol2_1.jpg")
+
+(facts :timeline-path
+  (original-path timeline-map) => (str "es/images/timeline/" timeline-file))


### PR DESCRIPTION
This is another one-off request path supported by the legacy thumbnailer. Here is an [example](http://img2.wikia.nocookie.net/__cb1422289387/television/es/images/timeline/bbe457792492f1b89f21a45aa6ca6088.png) image taken from [here](http://es.television.wikia.com/wiki/Wikivisi%C3%B3n:Administraci%C3%B3n). The paths take the form `/bucket/language/images/timeline/hash.png`. The way we decided to handle this was to allow any of the `:middle-dir` or `:top-dir` paths to be empty.

https://wikia-inc.atlassian.net/browse/MAIN-3622

/cc @nmonterroso @owend (since Nelson might be out)