### PR TITLE
only apply density magic when upsizing an image

### DIFF
--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -372,10 +372,15 @@ function svg_preoptions() {
 	local default_density=72
 	local orig_height=$($IDENTIFY -format "%h\n" "$IN" | head -1)
 	local orig_width=$($IDENTIFY -format "%w\n" "$IN" | head -1)
-	local width_density=`echo "(1.5 * ${WIDTH}) / (${orig_width} / ${default_density})" | bc -l`
-	local height_density=`echo "(1.5 * ${HEIGHT}) / (${orig_height} / ${default_density})" | bc -l`
 
-	THUMB_PRE_OPTIONS="-background none -density ${width_density}x${height_density}"
+	if [[ ${orig_width} -gt ${WIDTH} || ${orig_height} -gt ${HEIGHT} ]]; then
+		THUMB_PRE_OPTIONS="-background none"
+	else
+		local width_density=`echo "(1.5 * ${WIDTH}) / (${orig_width} / ${default_density})" | bc -l`
+		local height_density=`echo "(1.5 * ${HEIGHT}) / (${orig_height} / ${default_density})" | bc -l`
+
+		THUMB_PRE_OPTIONS="-background none -density ${width_density}x${height_density}"
+	fi
 }
 
 function thumb() {


### PR DESCRIPTION
@drsnyder 
https://wikia-inc.atlassian.net/browse/PLATFORM-808

The density stuff was originally added for [PLATFORM-608](https://wikia-inc.atlassian.net/browse/PLATFORM-608). 200 JIRA issues later, this is causing issues in SVGs that are downsized from the originals. In those cases, from my testing it seems OK to ignore the density stuff.