### PR TITLE
MAIN-3701 Add 'Surrogate-Key' header to image requests

### DIFF
--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -142,12 +142,12 @@
 
 (declare handle-thumbnail
          handle-original
-         image-params
+         get-image-params
          route-params->image-type)
 
 (defn image-request-handler
   [system request-type request &{:keys [thumbnail-mode height] :or {thumbnail-mode nil height nil} :as params}]
-  (let [image-params (image-params request request-type)
+  (let [image-params (get-image-params request request-type)
         image-params (if params (merge image-params params) image-params)]
     (condp = request-type
       :thumbnail (handle-thumbnail system image-params)
@@ -156,16 +156,16 @@
 (defn handle-thumbnail
   [system image-params]
   (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
-    (create-image-response thumb)
+    (create-image-response thumb image-params)
     (error-response 404 image-params)))
 
 (defn handle-original
   [system image-params]
   (if-let [file (get-original (store system) image-params)]
-    (create-image-response file)
+    (create-image-response file image-params)
     (error-response 404 image-params)))
 
-(defn image-params
+(defn get-image-params
   [request request-type]
   (let [route-params (assoc (:route-params request) :request-type request-type)
         options (extract-query-opts request)]

--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -2,11 +2,14 @@
   (:require [clojure.java.io :refer [file]]
             [compojure.route :refer [not-found]]
             [ring.util.response :refer [response status header]]
+            [vignette.media-types :refer :all]
             [vignette.storage.local :refer [create-stored-object]]
             [vignette.storage.protocols :refer :all]
             [vignette.util.thumbnail :refer :all]))
 
-(declare create-image-response)
+(declare create-image-response
+         add-surrogate-header
+         surrogate-key)
 
 (def error-image-file (file "public/brokenImage.jpg"))
 
@@ -30,12 +33,30 @@
 
 (defn create-image-response
   ([image image-map]
-    (-> (response (->response-object image))
-        (header "Content-Type" (content-type image))
-        (header "Content-Length" (content-length image))
-        (cond->
-          (:original image-map) (header "Content-Disposition"
-                                        (format "inline; filename=\"%s\""
-                                                (:original image-map))))))
+   (-> (response (->response-object image))
+       (header "Content-Type" (content-type image))
+       (header "Content-Length" (content-length image))
+       (header "X-Thumbnailer" "Vignette")
+       (cond->
+         (original image-map) (header "Content-Disposition"
+                                       (format "inline; filename=\"%s\""
+                                               (:original image-map)))
+         (and (wikia image-map)
+              (original image-map)
+              (image-type image-map)) (add-surrogate-header image-map))))
   ([image]
     (create-image-response image nil)))
+
+(defn add-surrogate-header
+  [response-map image-map]
+  (let [sk (surrogate-key image-map)]
+    (-> response-map
+        (header "Surrogate-Key" sk)
+        (header "X-Surrogate-Key" sk))))
+
+(defn surrogate-key
+  [image-map]
+  (try
+    (fully-qualified-original-path image-map)
+    (catch Exception e
+      (str "vignette-"(:original image-map)))))

--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -8,6 +8,7 @@
             [vignette.util.thumbnail :refer :all]))
 
 (declare create-image-response
+         add-content-disposition-header
          add-surrogate-header
          surrogate-key)
 
@@ -38,14 +39,18 @@
        (header "Content-Length" (content-length image))
        (header "X-Thumbnailer" "Vignette")
        (cond->
-         (original image-map) (header "Content-Disposition"
-                                       (format "inline; filename=\"%s\""
-                                               (:original image-map)))
+         (original image-map) (add-content-disposition-header image-map)
          (and (wikia image-map)
               (original image-map)
               (image-type image-map)) (add-surrogate-header image-map))))
   ([image]
     (create-image-response image nil)))
+
+(defn add-content-disposition-header
+  [response-map image-map]
+  (header response-map "Content-Disposition"
+          (format "inline; filename=\"%s\""
+                  (original image-map))))
 
 (defn add-surrogate-header
   [response-map image-map]

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -18,19 +18,19 @@
 
   (image-request-handler ..system.. :thumbnail ..request..) => ..response..
   (provided
-    (image-params ..request.. :thumbnail) => ..params..
+    (get-image-params ..request.. :thumbnail) => ..params..
     (handle-thumbnail ..system.. ..params..) => ..response..)
 
   (image-request-handler ..system.. :original ..request..) => ..response..
   (provided
-    (image-params ..request.. :original) => ..params..
+    (get-image-params ..request.. :original) => ..params..
     (handle-original ..system.. ..params..) => ..response..))
 
 (facts :handle-thumbnail
   (handle-thumbnail ..system.. ..params..) => ..response..
   (provided
     (u/get-or-generate-thumbnail ..system.. ..params..) => ..thumb..
-    (create-image-response ..thumb..) => ..response..)
+    (create-image-response ..thumb.. ..params..) => ..response..)
 
   (handle-thumbnail ..system.. ..params..) => ..error..
   (provided
@@ -42,7 +42,7 @@
   (provided
     (store ..system..) => ..store..
     (sp/get-original ..store.. ..params..) => ..original..
-    (create-image-response ..original..) => ..response..)
+    (create-image-response ..original.. ..params..) => ..response..)
 
   (handle-original ..system.. ..params..) => ..error..
   (provided

--- a/test/vignette/util/external_hotlinking_test.clj
+++ b/test/vignette/util/external_hotlinking_test.clj
@@ -31,5 +31,5 @@
        (let [request (generate-request original-url)
              route-match (route-matches original-route request)
              request (assoc-in request [:route-params] route-match)
-             image-params (image-params request :original)]
+             image-params (get-image-params request :original)]
          (image-params->forced-thumb-params image-params) => (contains force-thumb-params)))

--- a/test/vignette/util/image_response_test.clj
+++ b/test/vignette/util/image_response_test.clj
@@ -1,0 +1,21 @@
+(ns vignette.util.image-response-test
+ (:require [clojure.java.io :as io]
+           [clout.core :refer (route-compile route-matches)]
+           [midje.sweet :refer :all]
+           [ring.mock.request :refer :all]
+           [vignette.http.routes :refer :all]
+           [vignette.util.image-response :refer :all]
+           [vignette.storage.core :refer :all]
+           [vignette.storage.local :refer [create-stored-object]]
+           [vignette.util.image-response :as ir]))
+
+(facts :create-image-response
+  (let [image-map 
+        (get-image-params {:route-params (route-matches
+                                           original-route
+                                           (request :get "/lotr/3/35/ropes.jpg/revision/latest"))}
+                          :original)
+        response (create-image-response (create-stored-object "image-samples/ropes.jpg")  image-map)
+        response-headers (:headers response)]
+    (get response-headers "Surrogate-Key") => "lotr/images/3/35/ropes.jpg"
+    (get response-headers "Content-Disposition") => "inline; filename=\"ropes.jpg\""))


### PR DESCRIPTION
Add `Surrogate-Key` header to all image requests. This will enable more effective purging. The surrogate key is derived from the original image path on ceph including the bucket.

This will need to be integrated into MediaWiki. I'm also considering dialing down the `max-age` that we return so that images aren't cached "forever". That has broader implications though so this should be a good stop gap for handling DMCA requests.

https://wikia-inc.atlassian.net/browse/MAIN-3701

/cc @nmonterroso @ljagiello 
