### PR TITLE
Use the hash of the original path as the surrogate key

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
                  [ring "1.3.0"]
                  [slingshot "0.10.3"]
                  [useful "0.8.8"]
+                 [digest "1.4.4"]
                  [wikia/commons "0.1.3-SNAPSHOT"]]
   :profiles  {:dev  {:source-paths  ["dev"]
                      :plugins [[lein-midje "3.1.1"]]

--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -28,7 +28,7 @@
 (defn error-response
   ([code map]
    (if-let [image (error-image map)]
-     (status (create-image-response image) code)
+     (status (create-image-response image map) code)
      (not-found "Unable to fetch or generate image")))
   ([code]
    (error-response code nil)))

--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :refer [file]]
             [compojure.route :refer [not-found]]
             [ring.util.response :refer [response status header]]
+            [digest :as digest]
             [vignette.media-types :refer :all]
             [vignette.storage.local :refer [create-stored-object]]
             [vignette.storage.protocols :refer :all]
@@ -62,6 +63,6 @@
 (defn surrogate-key
   [image-map]
   (try
-    (fully-qualified-original-path image-map)
+    (digest/sha1 (fully-qualified-original-path image-map))
     (catch Exception e
       (str "vignette-"(:original image-map)))))

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -121,7 +121,7 @@
     (provided
      (u/get-or-generate-thumbnail ..system.. route-params) => nil
      (ir/error-image route-params) => ..thumb..
-     (ir/create-image-response ..thumb..) => {})
+     (ir/create-image-response ..thumb.. route-params) => {})
 
     ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/latest/thumbnail/width/10/height/10")) => (contains {:status 500})
     (provided

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -55,7 +55,9 @@
 
 (facts :thumbnail-path
        (thumbnail-path archive-map) => "images/thumb/archive/a/ab/12345!boat.jpg/200px-300px-thumbnail-boat.jpg"
-       (thumbnail-path latest-map) => "images/thumb/a/ab/boat.jpg/200px-300px-thumbnail-boat.jpg")
+       (thumbnail-path latest-map) => "images/thumb/a/ab/boat.jpg/200px-300px-thumbnail-boat.jpg"
+       (fully-qualified-original-path latest-map) => "bucket/images/a/ab/boat.jpg"
+       (fully-qualified-original-path archive-map) => "bucket/images/archive/a/ab/12345!boat.jpg")
 
 (facts :thumbnail-path-filled
        (thumbnail-path filled-map) => "images/thumb/a/ab/boat.jpg/200px-300px-thumbnail[fill=green]-boat.jpg")
@@ -63,7 +65,9 @@
 ; Neither of these should modify the resulting filename since they don't have sideffects
 (facts :lang-path
        (thumbnail-path lang-map) => "es/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail-boat.jpg"
-       (original-path lang-original-map) => "es/images/2/2a/Injustice_Vol2_1.jpg")
+       (original-path lang-original-map) => "es/images/2/2a/Injustice_Vol2_1.jpg"
+       (fully-qualified-original-path lang-map) => "bucket/es/images/a/ab/boat.jpg"
+       (fully-qualified-original-path lang-original-map) => "batman/es/images/2/2a/Injustice_Vol2_1.jpg")
 
 (facts :prefix-path
        (thumbnail-path prefix-path-map) => "pokemanshop/zh/de/images/thumb/a/ab/boat.jpg/200px-300px-thumbnail-boat.jpg")
@@ -73,4 +77,5 @@
        (original-path lang-original-map) => "es/images/2/2a/Injustice_Vol2_1.jpg")
 
 (facts :timeline-path
-  (original-path timeline-map) => (str "es/images/timeline/" timeline-file))
+  (original-path timeline-map) => (str "es/images/timeline/" timeline-file)
+  (fully-qualified-original-path timeline-map) => (str "television/es/images/timeline/" timeline-file))

--- a/test/vignette/util/image_response_test.clj
+++ b/test/vignette/util/image_response_test.clj
@@ -17,5 +17,5 @@
                           :original)
         response (create-image-response (create-stored-object "image-samples/ropes.jpg")  image-map)
         response-headers (:headers response)]
-    (get response-headers "Surrogate-Key") => "lotr/images/3/35/ropes.jpg"
+    (get response-headers "Surrogate-Key") => "7d1d24f2c2af364882953e8c97bf90092c2f7a08"
     (get response-headers "Content-Disposition") => "inline; filename=\"ropes.jpg\""))


### PR DESCRIPTION
Use the hash of the original path as the surrogate key instead of just the original path. There may be some limitations on the size of the key we can use and this should ensure that we comply.

/cc @pchojnacki @nmonterroso 