### PR TITLE
MWEB-1100 Add legacy routes for interactive maps

### DIFF
--- a/src/vignette/api/legacy/routes.clj
+++ b/src/vignette/api/legacy/routes.clj
@@ -53,7 +53,7 @@
 (def interactive-maps-route
   (route-compile "/:wikia:path-prefix/:original"
                  {:wikia interactive-maps-regex
-                  :path-prefix #"/\d/\d|"
+                  :path-prefix #"/\d+/\d+|"
                   :original original-regex}))
 
 (def interactive-maps-thumbnail-route

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -132,6 +132,18 @@
                (if-let [file (original-request->file request system image-params)]
                  (create-image-response file image-params)
                  (error-response 404 image-params))))
+        (GET alr/interactive-maps-route
+             request
+             (let [image-params (alr/route->interactive-maps-map (:route-params request))]
+               (if-let [file (original-request->file request system image-params)]
+                 (create-image-response file image-params)
+                 (error-response 404 image-params))))
+        (GET alr/interactive-maps-thumbnail-route
+             request
+             (let [image-params (alr/route->interactive-maps-thumbnail-map (:route-params request))]
+               (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
+                 (create-image-response thumb image-params)
+                 (error-response 404 image-params))))
         (GET "/ping" [] "pong")
         (files "/static/")
         (bad-request-path))

--- a/src/vignette/media_types.clj
+++ b/src/vignette/media_types.clj
@@ -31,6 +31,11 @@
         zone (query-opt object-map :zone)]
     (clojure.string/join "/" (filter not-empty [path-prefix image-type zone]))))
 
+
+(defmethod image-type->path-prefix "arbitrary" [object-map]
+  (when-let [path-prefix (query-opt object-map :path-prefix)]
+    path-prefix))
+
 (defmethod image-type->path-prefix :default [object-map]
   (throw+ {:type :convert-error
            :image-type (image-type object-map)}
@@ -86,7 +91,7 @@
         image-path (clojure.string/join "/" (filter not-empty ((juxt top-dir middle-dir) data)))
         filename (revision-filename data)]
     (if (nil? (revision data))
-      (clojure.string/join "/" [prefix image-path filename])
+      (clojure.string/join "/" (filter not-empty [prefix image-path filename]))
       (clojure.string/join "/" [prefix archive-dir image-path filename]))))
 
 (defn fully-qualified-original-path
@@ -125,7 +130,7 @@
 
 (defn thumbnail-path
   [data]
-  (let [thumb-path (clojure.string/join "/" ((juxt top-dir middle-dir) data))]
+  (let [thumb-path (clojure.string/join "/" (filter not-empty ((juxt top-dir middle-dir) data)))]
     (thumb-map->path data thumb-path)))
 
 (defmulti thumb-map->path (fn [data image-path]
@@ -134,7 +139,7 @@
 (defmethod thumb-map->path nil [data image-path]
   (let [prefix (thumb-map->prefix data)
         name (format "%s/%spx-%spx-%s%s-%s" (original data) (width data) (height data) (mode data) (query-opts-str data) (original data))]
-    (clojure.string/join "/" [prefix image-path name])))
+    (clojure.string/join "/" (filter not-empty [prefix image-path name]))))
 
 (defmethod thumb-map->path :default [data image-path]
   (let [prefix (thumb-map->prefix data)

--- a/test/vignette/api/legacy/routes_test.clj
+++ b/test/vignette/api/legacy/routes_test.clj
@@ -180,3 +180,32 @@
     (:path-prefix (:options map)) => "es"
     (:original map) => "bbe457792492f1b89f21a45aa6ca6088.png"
     (:image-type map) => "images"))
+
+(facts :map-original-route
+  (let [map (alr/route->interactive-maps-map
+              (route-matches alr/interactive-maps-route
+                           (request :get "/intmap_tile_set_4823/20150205173220!phpZDfa00.jpg")))]
+    (:request-type map) => :original
+    (:image-type map) => "arbitrary"
+    (:original map) => "20150205173220!phpZDfa00.jpg"
+    (:path-prefix map) => empty?
+    (:wikia map) => "intmap_tile_set_4823"))
+
+(facts :map-original-route-zoom
+  (let [map (alr/route->interactive-maps-map
+              (route-matches alr/interactive-maps-route
+                             (request :get "/intmap_tile_set_4692/3/1/2.png")))]
+    (:request-type map) => :original
+    (:image-type map) => "arbitrary"
+    (:original map) => "2.png"
+    (:path-prefix map) => "/3/1"
+    (:path-prefix (:options map)) => "3/1"))
+
+(facts :map-thumbnail-route
+  (let [map (alr/route->interactive-maps-thumbnail-map
+              (route-matches alr/interactive-maps-thumbnail-route
+                             (request :get "/intmap_tile_set_4823/thumb/20150205173220%21phpZDfa00.jpg/1110x300x5-20150205173220%21phpZDfa00.jpg")))]
+    (:width map) => "1110"
+    (:height map) => "300"
+    (:original map) => "20150205173220!phpZDfa00.jpg"
+    (:image-type map) => "arbitrary"))


### PR DESCRIPTION
Interactive maps stores images in the following forms which do not map to any of the currently known legacy image paths:

```
/intmap_tile_set_4823/20150205173220!phpZDfa00.jpg
/intmap_tile_set_4823/thumb/20150205173220%21phpZDfa00.jpg/1110x300x5-20150205173220%21phpZDfa00.jpg
/intmap_tile_set_4692/3/1/2.png
```

To support this we need to add explicit legacy support for these paths while also making the path generation code more tolerant of missing fields. 

This PR:

* Adds legacy routes to support interactive maps
* Makes the path generation more tolerant of empty fields
* Adds tests off the new routes

Issue [MWEB-1100](https://wikia-inc.atlassian.net/browse/MWEB-1100) is a side effect of moving all of the legacy traffic to vignette. See https://github.com/Wikia/chef-repo/pull/4197.

/cc @nmonterroso @ljagiello @rogatty 