### PR TITLE
Add custom route for imaps markers

### DIFF
--- a/src/vignette/api/legacy/routes.clj
+++ b/src/vignette/api/legacy/routes.clj
@@ -18,6 +18,7 @@
 (def video-params-regex #"(?i)v,\d{6},|v%2c\d{6}%2c|")
 (def zone-regex #"\/[a-z]+|") ; includes "archive"
 (def interactive-maps-regex #"intmap_tile_set_\d+")
+(def interactive-maps-marker-regex #"intmap_markers_\d+")
 
 (def thumbnail-route
   (route-compile "/:wikia:path-prefix/:image-type/thumb:zone/:top-dir/:middle-dir/:original/:videoparams:dimension:offset:thumbname"
@@ -73,6 +74,12 @@
                   :dimension dimension-regex
                   :offset offset-regex
                   :thumbname thumbname-regex}))
+
+(def interactive-maps-marker-route
+  (route-compile "/:wikia/:original"
+                 {:wikia interactive-maps-marker-regex
+                  :original original-regex}))
+
 
 (defn archive? [map]
   (= (:zone map) (str "/" archive-dir)))

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -144,6 +144,12 @@
                (if-let [file (original-request->file request system image-params)]
                  (create-image-response file image-params)
                  (error-response 404 image-params))))
+        (GET alr/interactive-maps-marker-route
+             request
+             (let [image-params (alr/route->interactive-maps-map (:route-params request))]
+               (if-let [file (original-request->file request system image-params)]
+                 (create-image-response file image-params)
+                 (error-response 404 image-params))))
         (GET alr/interactive-maps-thumbnail-route
              request
              (let [image-params (alr/route->interactive-maps-thumbnail-map (:route-params request))]

--- a/test/vignette/api/legacy/routes_test.clj
+++ b/test/vignette/api/legacy/routes_test.clj
@@ -212,6 +212,16 @@
     (:path-prefix map) => "/3/1"
     (:path-prefix (:options map)) => "3/1"))
 
+(facts :map-marker-route
+  (let [map (alr/route->interactive-maps-map
+              (route-matches alr/interactive-maps-marker-route
+                             (request :get "/intmap_markers_109/60px-20140716115821!phpZDweHO.png")))]
+    (:request-type map) => :original
+    (:image-type map) => "arbitrary"
+    (:original map) => "60px-20140716115821!phpZDweHO.png"
+    (:path-prefix map) => nil
+    (:wikia map) => "intmap_markers_109"))
+
 (facts :map-thumbnail-route
   (let [map (alr/route->interactive-maps-thumbnail-map
               (route-matches alr/interactive-maps-thumbnail-route


### PR DESCRIPTION
Add custom route for imaps markers. They take the form of `/intmap_markers_\d+/<file>`. The `<file>` portion starts with strings of the form `\d+px-<file>` but they are not thumbnailed.

https://wikia-inc.atlassian.net/browse/MAIN-3808

/cc @nmonterroso @rogatty 