### PR TITLE
PLATFORM-888 Add support for purging varnish via the PURGE method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ Below is a list of environment variables that will affect the vignette runtime.
  * `VIGNETTE_SERVER_MAX_THREADS`  minimum number of threads to allocate for jetty [150]
  * `VIGNETTE_SERVER_QUEUE_SIZE`   queue size to allocate for jetty [9000]
  * `ENABLE_ACCESS_LOG`            enable the NCSA access log [false]
- * `ACCESS_LOG_FILE`              NCSA acces log file [/tmp/Vignette-access.log]
+ * `ACCESS_LOG_FILE`              NCSA acces log file [/tmp/vignette-access.log]
  * `IMAGEMAGICK_BASE`             path to the root of the ImageMagick installation [/usr/local]
  * `GETOPT`                       when running on osx, install gnu-getopt using brew. see bin/thumbnail
  * `CONVERT_CONSTRAINTS`          universal options to pass to ImageMagick. see bin/thumbnail
  * `UNSUPPORTED_REDIRECT_HOST`    on an unsupported legacy thumbnail request, host to redirect
+ * `FASTLY_API_ID`                the Fastly API id
+ * `FASTLY_API_AUTH_KEY`          the Fastly API auth key
+ * `FASTLY_API_URL`               the Fastly API url [https://api.fastly.com]
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ centered either vertically or horizontally, depending on the longer dimension.
 | :--------:                                                        | :-----------: |
 | ![beach fixed-aspect-ratio](/assets/fixed-aspect-ratio/beach.jpg) | ![carousel fixed-aspect-ratio](/assets/fixed-aspect-ratio/carousel.jpg) |
 
-Example: [http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/fixed-aspect-ratio/width/200/height/200?fill=blue](http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/zoom-crop/width/200/height/200)
+Example: [http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/fixed-aspect-ratio/width/200/height/200?fill=blue](http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/fixed-aspect-ratio/width/200/height/200?fill=blue)
 
 
 Note that the `fill=blue` URL parameter isn’t required. It’s there to help
@@ -117,7 +117,7 @@ This behaves the same as above except that it will not upscale the image. This
 is convenient when you want to preserve the aspect ratio but you don’t want the
 side effects that can result from upscaling the image.
 
-Example: [http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/fixed-aspect-ratio-down/width/200/height/200?fill=blue](http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/zoom-crop/width/200/height/200)
+Example: [http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/fixed-aspect-ratio-down/width/200/height/200?fill=blue](http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/fixed-aspect-ratio-down/width/200/height/200?fill=blue)
 
 #### scale-to-width
 
@@ -139,7 +139,7 @@ aspect ratio will be preserved. Image upscaling is permitted.
 | :--------:                                                        | :-----------: |
 | ![beach thumbnail](/assets/thumbnail/beach.jpg) | ![carousel thumbnail](/assets/thumbnail/carousel.jpg) |
 
-Example: [http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/thumbnail/width/200/height/200](http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/zoom-crop/width/200/height/200)
+Example: [http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/thumbnail/width/200/height/200](http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/thumbnail/width/200/height/200)
 
 #### thumbnail-down
 

--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -80,6 +80,25 @@ cat <<EOF
 EOF
 }
 
+# Test for array containment.
+# Example: $(contains "${A[@]}", "foo") == "y"
+# Returns "y"" when the object is contained in the array and "n" otherwise.
+# http://stackoverflow.com/questions/3685970/check-if-an-array-contains-a-value
+function contains() {
+	local n=$#
+	local value=${!n}
+	for ((i=1;i < $#;i++)) {
+		if [ "${!i}" == "${value}" ]; then
+			echo "y"
+			return 0
+		fi
+	}
+
+	echo "n"
+	return 1
+}
+
+
 OS=$(uname)
 SHORTOPTS="h"
 LONGOPTS="in:,out:,width:,height:,fuzz:,help,fill:,still,mode:,animated,x-offset:,window-width:,y-offset:,window-height:"
@@ -185,10 +204,13 @@ if [ "$OUT"X = "X" ]; then
 	exit 1
 fi
 
+MODES_REQUIRING_HEIGHT=("fixed-aspect-ratio" "fixed-aspect-ratio-down" "thumbnail" "thumbnail-down" "top-crop" "top-crop-down" "window-crop-fixed" "zoom-crop" "zoom-crop-down")
 if [ "$HEIGHT"X = "X" ]; then
-	echo "--height required"
-	usage
-	exit 1
+	if [ $(contains "${MODES_REQUIRING_HEIGHT[@]}" "${MODE}") == "y" ]; then
+		echo "--height required for mode ${MODE}"
+		usage
+		exit 1
+	fi
 fi
 
 if [ "$WIDTH"X = "X" ]; then

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -16,11 +16,13 @@
             [vignette.storage.core :refer [create-image-storage]]
             [vignette.storage.local :refer [create-local-storage-system]]
             [vignette.storage.s3 :refer [create-s3-storage-system storage-creds]]
+            [vignette.caching.edge.fastly :refer [create-fastly-api fastly-creds]]
             [vignette.system :refer :all]
             [vignette.util.filesystem :as fs]
             [vignette.util.integration :as itg]
             [vignette.util.thumbnail :as u]
             [vignette.util.query-options :as q]
+            [vignette.caching.edge.fastly :as fastly]
             [wikia.common.logger :as log]
             [wikia.common.perfmonitoring.core :as perf])
   (:use [environ.core]))
@@ -40,15 +42,17 @@
                             :height "10"
                             :width "10"})
 
+(def fastly (create-fastly-api fastly-creds))
+
 (def los  (create-local-storage-system itg/integration-path))
 (def lis  (create-image-storage los))
 
-(def system-local (create-system lis))
+(def system-local (create-system lis nil))
 
 (def s3os  (create-s3-storage-system storage-creds))
 (def s3s   (create-image-storage s3os))
 
-(def system-s3 (create-system s3s))
+(def system-s3 (create-system s3s fastly))
 
 (comment
   (start S 8080)

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  [slingshot "0.10.3"]
                  [useful "0.8.8"]
                  [digest "1.4.4"]
+                 [clj-http "1.0.1"]
                  [wikia/commons "0.1.3-SNAPSHOT"]]
   :profiles  {:dev  {:source-paths  ["dev"]
                      :plugins [[lein-midje "3.1.1"]]

--- a/src/vignette/caching/edge/fastly.clj
+++ b/src/vignette/caching/edge/fastly.clj
@@ -1,0 +1,47 @@
+(ns vignette.caching.edge.fastly
+  (:require [clj-http.client :as client]
+            [vignette.protocols :refer :all]
+            [wikia.common.logger :as log]
+            [wikia.common.perfmonitoring.core :as perf])
+  (:use [environ.core]))
+
+(def default-fastly-api-url "https://api.fastly.com")
+
+(def fastly-creds {:id       (env :fastly-api-id)
+                   :auth-key (env :fastly-api-auth-key)
+                   :api-url  (env :fastly-api-url default-fastly-api-url)})
+
+(declare purge-request-url
+         api-params)
+
+(defrecord FastlyAPI [id auth-key fastly-api-url]
+  CachePurgeAPI
+  (purge [this uri surrogate-key]
+    (perf/publish {:purge-count 1})
+    (let [response (client/post (purge-request-url (:fastly-api-url this)
+                                                   (:id this)
+                                                   surrogate-key)
+                                (api-params (:auth-key this)))]
+      (if (not= (:status response) 200)
+        (do (perf/publish {:failed-purge-count 1})
+            (log/warn (:body response) {:path uri :key surrogate-key})
+            false)
+        (do
+          (log/info (format "purged: %s using key %s" uri surrogate-key) {:path uri :key surrogate-key})
+          true)))))
+
+(defn create-fastly-api
+  [creds]
+  (->FastlyAPI (:id creds) (:auth-key creds) (:api-url creds)))
+
+(defn purge-request-url
+  [fastly-api id surrogate-key]
+  (format "%s/service/%s/purge/%s"
+          fastly-api
+          id
+          surrogate-key))
+
+(defn api-params
+  [auth-key]
+  {:headers {"Fastly-Key" auth-key
+             "Accept" "application/json"}})

--- a/src/vignette/caching/edge/fastly.clj
+++ b/src/vignette/caching/edge/fastly.clj
@@ -11,6 +11,10 @@
                    :auth-key (env :fastly-api-auth-key)
                    :api-url  (env :fastly-api-url default-fastly-api-url)})
 
+(defn empty-fastly-creds?
+  [creds]
+  (some nil? (vals creds)))
+
 (declare purge-request-url
          api-params)
 
@@ -24,7 +28,7 @@
                                 (api-params (:auth-key this)))]
       (if (not= (:status response) 200)
         (do (perf/publish {:failed-purge-count 1})
-            (log/warn (:body response) {:path uri :key surrogate-key})
+            (log/warn "vignette fastly purge failed" {:path uri :key surrogate-key :error (:body response)})
             false)
         (do
           (log/info (format "purged: %s using key %s" uri surrogate-key) {:path uri :key surrogate-key})

--- a/src/vignette/core.clj
+++ b/src/vignette/core.clj
@@ -5,7 +5,7 @@
             [vignette.storage.local :refer [create-local-storage-system]]
             [vignette.storage.protocols :refer :all]
             [vignette.storage.s3 :refer [create-s3-storage-system storage-creds]]
-            [vignette.caching.edge.fastly :refer [create-fastly-api fastly-creds]]
+            [vignette.caching.edge.fastly :refer [create-fastly-api fastly-creds empty-fastly-creds?]]
             [vignette.system :refer :all]
             [vignette.util.integration :as i]
             [wikia.common.perfmonitoring.core :as perf])
@@ -20,10 +20,6 @@
                  :default 8080
                  :parse-fn #(Integer/parseInt %)
                  :validate  [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]])
-
-(defn empty-fastly-creds?
-  [creds]
-  (some nil? (vals creds)))
 
 (defn -main [& args]
   (let [parsed-opts (cli/parse-opts args cli-specs)

--- a/src/vignette/core.clj
+++ b/src/vignette/core.clj
@@ -5,6 +5,7 @@
             [vignette.storage.local :refer [create-local-storage-system]]
             [vignette.storage.protocols :refer :all]
             [vignette.storage.s3 :refer [create-s3-storage-system storage-creds]]
+            [vignette.caching.edge.fastly :refer [create-fastly-api fastly-creds]]
             [vignette.system :refer :all]
             [vignette.util.integration :as i]
             [wikia.common.perfmonitoring.core :as perf])
@@ -19,6 +20,10 @@
                  :default 8080
                  :parse-fn #(Integer/parseInt %)
                  :validate  [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]])
+
+(defn empty-fastly-creds?
+  [creds]
+  (some nil? (vals creds)))
 
 (defn -main [& args]
   (let [parsed-opts (cli/parse-opts args cli-specs)
@@ -39,6 +44,8 @@
                              (create-local-storage-system i/integration-path))
                            (create-s3-storage-system storage-creds))
           image-store (create-image-storage object-storage)
-          system (create-system image-store)]
+          cache (when (not (empty-fastly-creds? fastly-creds))
+                  (create-fastly-api fastly-creds))
+          system (create-system image-store cache)]
       (println (format "Mode: %s. Starting server on %d..." (:mode opts) (:port opts)))
       (start system (:port opts)))))

--- a/src/vignette/http/compojure.clj
+++ b/src/vignette/http/compojure.clj
@@ -5,7 +5,7 @@
     [path args & body]
       (compile-route :purge path args body))
 
-(defmacro GET+ "Generate a route that matches GET or PURGE"
+(defmacro GET+PURGE "Generate a route that matches GET or PURGE"
   [path args & body]
   `(context "" []
         (GET ~path ~args ~@body)

--- a/src/vignette/http/compojure.clj
+++ b/src/vignette/http/compojure.clj
@@ -1,0 +1,12 @@
+(ns vignette.http.compojure
+  (:require [compojure.core :refer [compile-route context GET]]))
+
+(defmacro PURGE "Generate a PURGE route."
+    [path args & body]
+      (compile-route :purge path args body))
+
+(defmacro GET+ "Generate a route that matches GET or PURGE"
+  [path args & body]
+  `(context "" []
+        (GET ~path ~args ~@body)
+        (PURGE ~path ~args ~@body)))

--- a/src/vignette/http/middleware.clj
+++ b/src/vignette/http/middleware.clj
@@ -20,10 +20,12 @@
         (let [message (:message &throw-context)
               thumb-map (:thumb-map e) ; if present, we'll try to thumbnail the error response
               response-code (or (:response-code e) 500)
-              context (assoc (dissoc e :type :thumb-map :response-code) :host hostname)]
+              context (-> e
+                          (dissoc :type :thumb-map :response-code :out-string)
+                          (assoc :host hostname))]
           (when (>= response-code 500)
             (perf/publish {:convert-error 1})
-            (println message ":" (:uri request))
+            (println message ":" (:uri request) " error: " (:out-string e))
             (log/warn message
                       (merge {:path (:uri request)
                               :query (:query-string request)

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -83,7 +83,8 @@
                   :thumbnail-mode #"scale-to-width"
                   :width size-regex}))
 
-(declare image-request-handler)
+(declare image-request-handler
+         add-height-to-route-params)
 
 (defn original-request->file
   [request system image-params]
@@ -97,13 +98,13 @@
   (-> (routes
         (GET+ scale-to-width-route
              request
-             (image-request-handler system :thumbnail (assoc request :height :auto)))
+             (image-request-handler system :thumbnail (add-height-to-route-params request :auto)))
         (GET+ window-crop-route
              request
-             (image-request-handler system :thumbnail (assoc request :height :auto)))
+             (image-request-handler system :thumbnail (add-height-to-route-params request :auto)))
         (GET+ window-crop-fixed-route
              request
-             (image-request-handler system :thumbnail (assoc request :height :auto)))
+             (image-request-handler system :thumbnail (add-height-to-route-params request :auto)))
         (GET+ thumbnail-route
              request
              (image-request-handler system :thumbnail request))
@@ -162,6 +163,10 @@
       (request-timer)
       (add-headers)))
 
+(defn add-height-to-route-params
+  [request height]
+  (assoc-in request [:route-params :height] height))
+
 (declare request-method-handler
          handle-thumbnail
          handle-original
@@ -207,7 +212,7 @@
       (background-purge edge-cache image-params uri)
       (-> (response "")
           (status 202)))
-    (not-found "No purger available")))
+    (not-found "No purger available\n")))
 
 (defn background-purge
   [cache image-params uri]

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -3,7 +3,7 @@
             [clojure.java.io :as io]
             [clout.core :refer [route-compile route-matches]]
             [compojure.core :refer [routes GET]]
-            [vignette.http.compojure :refer [GET+]]
+            [vignette.http.compojure :refer [GET+PURGE]]
             [compojure.route :refer [files not-found]]
             [environ.core :refer [env]]
             [ring.middleware.params :refer [wrap-params]]
@@ -96,19 +96,19 @@
 (defn app-routes
   [system]
   (-> (routes
-        (GET+ scale-to-width-route
+        (GET+PURGE scale-to-width-route
              request
              (image-request-handler system :thumbnail request))
-        (GET+ window-crop-route
+        (GET+PURGE window-crop-route
              request
              (image-request-handler system :thumbnail request))
-        (GET+ window-crop-fixed-route
+        (GET+PURGE window-crop-fixed-route
              request
              (image-request-handler system :thumbnail request))
-        (GET+ thumbnail-route
+        (GET+PURGE thumbnail-route
              request
              (image-request-handler system :thumbnail request))
-        (GET+ original-route
+        (GET+PURGE original-route
              request
              (image-request-handler system :original request))
 

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -167,6 +167,7 @@
          handle-original
          handle-purge
          get-image-params
+         background-purge
          route-params->image-type)
 
 (defmulti image-request-handler (fn [system request-type request]
@@ -197,8 +198,6 @@
   (if-let [file (get-original (store system) image-params)]
     (create-image-response file image-params)
     (error-response 404 image-params)))
-
-(declare background-purge)
 
 (defn handle-purge
   [system image-params uri]

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -98,13 +98,13 @@
   (-> (routes
         (GET+ scale-to-width-route
              request
-             (image-request-handler system :thumbnail (add-height-to-route-params request :auto)))
+             (image-request-handler system :thumbnail request))
         (GET+ window-crop-route
              request
-             (image-request-handler system :thumbnail (add-height-to-route-params request :auto)))
+             (image-request-handler system :thumbnail request))
         (GET+ window-crop-fixed-route
              request
-             (image-request-handler system :thumbnail (add-height-to-route-params request :auto)))
+             (image-request-handler system :thumbnail request))
         (GET+ thumbnail-route
              request
              (image-request-handler system :thumbnail request))

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -2,7 +2,8 @@
   (:require [cheshire.core :refer :all]
             [clojure.java.io :as io]
             [clout.core :refer [route-compile route-matches]]
-            [compojure.core :refer [routes GET ANY]]
+            [compojure.core :refer [routes GET]]
+            [vignette.http.compojure :refer [GET+]]
             [compojure.route :refer [files]]
             [environ.core :refer [env]]
             [ring.middleware.params :refer [wrap-params]]
@@ -94,19 +95,19 @@
 (defn app-routes
   [system]
   (-> (routes
-        (GET scale-to-width-route
+        (GET+ scale-to-width-route
              request
              (image-request-handler system :thumbnail (assoc request :height :auto)))
-        (GET window-crop-route
+        (GET+ window-crop-route
              request
              (image-request-handler system :thumbnail (assoc request :height :auto)))
-        (GET window-crop-fixed-route
+        (GET+ window-crop-fixed-route
              request
              (image-request-handler system :thumbnail (assoc request :height :auto)))
-        (GET thumbnail-route
+        (GET+ thumbnail-route
              request
              (image-request-handler system :thumbnail request))
-        (GET original-route
+        (GET+ original-route
              request
              (image-request-handler system :original request))
 

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -83,8 +83,7 @@
                   :thumbnail-mode #"scale-to-width"
                   :width size-regex}))
 
-(declare image-request-handler
-         add-height-to-route-params)
+(declare image-request-handler)
 
 (defn original-request->file
   [request system image-params]
@@ -162,10 +161,6 @@
       (exception-catcher)
       (request-timer)
       (add-headers)))
-
-(defn add-height-to-route-params
-  [request height]
-  (assoc-in request [:route-params :height] height))
 
 (declare request-method-handler
          handle-thumbnail

--- a/src/vignette/protocols.clj
+++ b/src/vignette/protocols.clj
@@ -2,5 +2,9 @@
 
 (defprotocol SystemAPI
   (store [this])
+  (cache [this])
   (start [this port])
   (stop [this]))
+
+(defprotocol CachePurgeAPI
+  (purge [this uri surrogate-key]))

--- a/src/vignette/system.clj
+++ b/src/vignette/system.clj
@@ -14,6 +14,8 @@
   SystemAPI
   (store [this]
     (:store (:state this)))
+  (cache [this]
+    (:cache (:state this)))
   (start [this port]
     (swap! (:running (:state this))
            (fn [_]
@@ -33,5 +35,7 @@
       (.stop server))))
 
 (defn create-system
-  [store]
-  (->VignetteSystem {:store store :running (atom nil)}))
+  ([store cache]
+   (->VignetteSystem {:store store :cache cache :running (atom nil)}))
+  ([store]
+   (create-system store nil)))

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -74,6 +74,7 @@
                (file-exists? temp-file))) (io/file temp-file)
       :else (throw+ {:type :convert-error
                      :error-code (:exit sh-out)
+                     :out-string (:out sh-out)
                      :error-string (:err sh-out)}
                     "thumbnailing error"))))
 

--- a/test/vignette/caching/edge/fastly_test.clj
+++ b/test/vignette/caching/edge/fastly_test.clj
@@ -17,3 +17,7 @@
     (api-params ..auth..) => ..params..
     (client/post ..url.. ..params..) => {:status 200}))
 
+(facts :empty-fastly-creds
+  (empty-fastly-creds? {:a true :b true}) => falsey
+  (empty-fastly-creds? {:a true :b nil}) => truthy)
+

--- a/test/vignette/caching/edge/fastly_test.clj
+++ b/test/vignette/caching/edge/fastly_test.clj
@@ -1,0 +1,19 @@
+(ns vignette.caching.edge.fastly-test
+  (:require [midje.sweet :refer :all]
+            [clj-http.client :as client]
+            [vignette.protocols :refer :all]
+            [vignette.caching.edge.fastly :refer :all]))
+
+(facts :purge
+  (purge (create-fastly-api {:id ..id.. :auth-key ..auth.. :api-url default-fastly-api-url}) ..uri.. ..key..) => false
+  (provided
+    (purge-request-url default-fastly-api-url ..id.. ..key..) => ..url..
+    (api-params ..auth..) => ..params..
+    (client/post ..url.. ..params..) => {:status 500})
+
+  (purge (create-fastly-api {:id ..id.. :auth-key ..auth.. :api-url default-fastly-api-url}) ..uri.. ..key..) => true
+  (provided
+    (purge-request-url default-fastly-api-url ..id.. ..key..) => ..url..
+    (api-params ..auth..) => ..params..
+    (client/post ..url.. ..params..) => {:status 200}))
+

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -26,6 +26,18 @@
     (get-image-params ..request.. :original) => ..params..
     (handle-original ..system.. ..params..) => ..response..))
 
+(facts :image-request-handler :scale-to-width
+  (let [route-params (route-matches scale-to-width-route (request :get "muppet/images/d/d4/Mo-Yet.jpg/revision/latest/scale-to-width/212"))
+       request {:request-method :get :route-params route-params}
+       merged-route-params (merge route-params {:thumbnail-mode "scale-to-width" :height :auto})]
+    (image-request-handler ..system.. :thumbnail
+                           request
+                           :thumbnail-mode "scale-to-width"
+                           :height :auto)  => (contains {:status 200})
+   (provided
+    (get-image-params request :thumbnail) => merged-route-params
+    (handle-thumbnail ..system.. merged-route-params) => {:body nil :status 200})))
+
 (facts :handle-thumbnail
   (handle-thumbnail ..system.. ..params..) => ..response..
   (provided

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -38,6 +38,20 @@
     (get-image-params request :thumbnail) => merged-route-params
     (handle-thumbnail ..system.. merged-route-params) => {:body nil :status 200})))
 
+(facts :image-request-handler :window-crop
+  (let [route-params (route-matches window-crop-route
+                      (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/103"))
+        request {:request-method :get :route-params route-params}
+        merged-route-params (merge route-params {:thumbnail-mode "window-crop" :height :auto})]
+    (image-request-handler ..system.. :thumbnail
+                           request
+                           :thumbnail-mode "window-crop"
+                           :height :auto)  => (contains {:status 200})
+
+   (provided
+    (get-image-params request :thumbnail) => merged-route-params
+    (handle-thumbnail ..system.. merged-route-params) => {:body nil :status 200})))
+
 (facts :handle-thumbnail
   (handle-thumbnail ..system.. ..params..) => ..response..
   (provided

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -148,6 +148,8 @@
   ((app-routes nil) (request :get "/not-a-valid-route")) => (contains {:status 404}))
 
 (facts :app-routes-thumbnail
+  ((app-routes ..system..) (request :purge "/lotr/3/35/ropes.jpg/revision/latest/thumbnail/width/10/height/10")) => (contains {:status 202})
+
   (let [route-params {:request-type :thumbnail
                       :image-type "images"
                       :original "ropes.jpg"
@@ -174,6 +176,7 @@
       (u/get-or-generate-thumbnail ..system.. route-params) =throws=> (NullPointerException.))))
 
 (facts :app-routes-original
+  ((app-routes ..system..) (request :purge "/lotr/3/35/ropes.jpg/revision/latest")) => (contains {:status 202})
 
   (let [route-params {:request-type :original
                       :image-type "images"

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -29,28 +29,39 @@
 (facts :image-request-handler :scale-to-width
   (let [route-params (route-matches scale-to-width-route (request :get "muppet/images/d/d4/Mo-Yet.jpg/revision/latest/scale-to-width/212"))
        request {:request-method :get :route-params route-params}
-       merged-route-params (merge route-params {:thumbnail-mode "scale-to-width" :height :auto})]
+       merged-route-params (merge route-params {:thumbnail-mode "scale-to-width" :height :auto})
+       image-params (merge merged-route-params {:options {} :image-type "images" :request-type :thumbnail})]
     (image-request-handler ..system.. :thumbnail
                            request
                            :thumbnail-mode "scale-to-width"
                            :height :auto)  => (contains {:status 200})
    (provided
-    (get-image-params request :thumbnail) => merged-route-params
-    (handle-thumbnail ..system.. merged-route-params) => {:body nil :status 200})))
+    (handle-thumbnail ..system.. image-params) => {:body nil :status 200})))
 
 (facts :image-request-handler :window-crop
   (let [route-params (route-matches window-crop-route
                       (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/103"))
         request {:request-method :get :route-params route-params}
-        merged-route-params (merge route-params {:thumbnail-mode "window-crop" :height :auto})]
+        merged-route-params (merge route-params {:thumbnail-mode "window-crop" :height :auto :request-type :thumbnail})
+        image-params (merge merged-route-params {:options {} :image-type "images"})]
     (image-request-handler ..system.. :thumbnail
                            request
                            :thumbnail-mode "window-crop"
                            :height :auto)  => (contains {:status 200})
 
    (provided
-    (get-image-params request :thumbnail) => merged-route-params
-    (handle-thumbnail ..system.. merged-route-params) => {:body nil :status 200})))
+    (handle-thumbnail ..system.. image-params) => {:body nil :status 200})))
+
+(facts :image-request-handler :original
+  (let [route-params (route-matches original-route
+                      (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest"))
+        request {:request-method :get :route-params route-params}
+        image-params (merge route-params {:options {} :image-type "images" :request-type :original})]
+    (println image-params)
+    (image-request-handler ..system.. :original request)  => (contains {:status 200})
+
+   (provided
+    (handle-original ..system.. image-params) => {:body nil :status 200})))
 
 (facts :handle-thumbnail
   (handle-thumbnail ..system.. ..params..) => ..response..

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -35,25 +35,8 @@
     (cache ..system..) => ..cache..
     (background-purge ..cache.. ..image-params.. ..uri..) => nil))
 
-(facts :image-request-handler :scale-to-width
-  (let [route-params (route-matches scale-to-width-route (request :get "/muppet/images/d/d4/Mo-Yet.jpg/revision/latest/scale-to-width/212"))
-       merged-route-params (merge route-params {:height :auto})
-       request {:request-method :get :route-params merged-route-params}
-       image-params (merge merged-route-params {:options {} :image-type "images" :request-type :thumbnail})]
-    (image-request-handler ..system.. :thumbnail request)  => (contains {:status 200})
-   (provided
-    (handle-thumbnail ..system.. image-params) => {:body nil :status 200})))
-
-(facts :image-request-handler :window-crop
-  (let [route-params (route-matches window-crop-route
-                      (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/103"))
-        merged-route-params (merge route-params {:height :auto})
-        request {:request-method :get :route-params merged-route-params}
-        image-params (merge merged-route-params {:options {} :image-type "images" :request-type :thumbnail})]
-    (image-request-handler ..system.. :thumbnail request)  => (contains {:status 200})
-
-   (provided
-    (handle-thumbnail ..system.. image-params) => {:body nil :status 200})))
+(facts :get-image-params
+  (get-image-params {:route-params {:wikia "foo"}} :foo) => {:wikia "foo" :options {} :image-type "images" :request-type :foo})
 
 (facts :image-request-handler :thumbnail
   (let [route-params (route-matches thumbnail-route
@@ -151,13 +134,6 @@
   ((app-routes nil) (request :get "/not-a-valid-route")) => (contains {:status 404}))
 
 (facts :app-routes-thumbnail
-  (let [request-map (request :purge "/lotr/3/35/ropes.jpg/revision/latest/thumbnail/width/10/height/10")
-        uri (:uri request-map)]
-    ((app-routes ..system..) request-map) => (contains {:status 202})
-    (provided
-      (get-image-params anything :thumbnail) => ..image-params..
-      (handle-purge ..system.. ..image-params.. uri) => {:status 202}))
-
   (let [route-params {:request-type :thumbnail
                       :image-type "images"
                       :original "ropes.jpg"
@@ -184,11 +160,6 @@
       (u/get-or-generate-thumbnail ..system.. route-params) =throws=> (NullPointerException.))))
 
 (facts :app-routes-original
-  ((app-routes ..system..) (request :purge "/lotr/3/35/ropes.jpg/revision/latest")) => (contains {:status 202})
-  (provided
-    (get-image-params anything :original) => ..image-params..
-    (handle-purge ..system.. ..image-params.. anything) => {:status 202})
-
   (let [route-params {:request-type :original
                       :image-type "images"
                       :original "ropes.jpg"


### PR DESCRIPTION
Add support for purging varnish via the PURGE method. To add support a request macro including both `GET` and `PURGE` was added to keep the routing logic to a minimum. As part of this process I further simplified the vignette routes by moving the `:thumbnail-mode` logic into the routes and out of the handler. This exposed the dangling `{:height :auto}` which was also moved out of the handler logic and into `bin/thumbnail`.

To handle the purging a `cache` was added to the `SystemAPI`. A new protocol for purging was also added to provide an interface to this behavior. See `CachePurgeAPI`. It supports `(purge [uri surrogate-key])`. Finally, a fastly implementation for the protocol is provided that allows the credentials to be injected via the environment.

The corresponding changes on the MW side still need to be implemented.

https://wikia-inc.atlassian.net/browse/PLATFORM-888

/cc @nmonterroso @macbre @harnash 