### PR TITLE
MAIN-3931 Do not add the format to the filename if thumb extension is the same as the original

### DIFF
--- a/src/vignette/api/legacy/routes.clj
+++ b/src/vignette/api/legacy/routes.clj
@@ -147,13 +147,22 @@
       map
       (assoc map :original (clojure.string/replace (:original map) #"^\d+!" "")))))
 
+(defn image->format
+  [file]
+  (let [[_ ext] (re-find #"(?i)\.([a-z]+)$" file)]
+    (when ext
+      (.toLowerCase ext))))
+
 (defn route->options
   [map]
-  (let [[_ format] (re-find #"(?i)\.([a-z]+)$" (get map :thumbname ""))
+  (let [thumb-format (image->format (get map :thumbname ""))
+        original-format (image->format (get map :original ""))
+        to-format (when (not= thumb-format original-format)
+                 thumb-format)
         [_ path-prefix] (re-find #"^/([/a-z0-9-]+)$" (get map :path-prefix ""))
         zone (zone map)
         options (cond-> {}
-                     format (assoc :format (.toLowerCase format))
+                     to-format (assoc :format to-format)
                      path-prefix (assoc :path-prefix path-prefix)
                      zone (assoc :zone zone))]
     (assoc map :options options)))

--- a/test/vignette/api/legacy/routes_test.clj
+++ b/test/vignette/api/legacy/routes_test.clj
@@ -6,7 +6,7 @@
 
 (facts :thumbnail-route
   (let [matched (route-matches alr/thumbnail-route
-                               (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.webp"))
+                               (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.WEBP"))
         matched (alr/route->thumb-map matched)]
     (:request-type matched) => :thumbnail
     (alr/archive? matched) => false
@@ -17,7 +17,7 @@
     (:width matched) => "185"
     (:wikia matched) => "happywheels"
     (:revision matched) => "latest"
-    (:thumbname matched) => "SuperMario64_20.webp"
+    (:thumbname matched) => "SuperMario64_20.WEBP"
     (:format (:options matched)) => "webp")
 
   (let [matched (alr/route->thumb-map
@@ -34,7 +34,7 @@
     (:height matched) => :auto
     (:revision matched) => "20101213101955"
     (:thumbname matched) => "6x01-Phoebe.jpg"
-    (:format (:options matched)) => "jpg")
+    (get (:options matched) :format nil) => nil?)
 
   (let [matched (alr/route->thumb-map
                   (route-matches alr/thumbnail-route
@@ -50,8 +50,7 @@
     (:height matched) => "200"
     (:thumbnail-mode matched) => "zoom-crop"
     (:revision matched) => "20101213101955"
-    (:thumbname matched) => "6x01-Phoebe.jpg"
-    (:format (:options matched)) => "jpg")
+    (:thumbname matched) => "6x01-Phoebe.jpg")
 
   (let [map (alr/route->thumb-map
               (route-matches alr/thumbnail-route

--- a/test/vignette/api/legacy/routes_test.clj
+++ b/test/vignette/api/legacy/routes_test.clj
@@ -229,3 +229,10 @@
     (:height map) => "300"
     (:original map) => "20150205173220!phpZDfa00.jpg"
     (:image-type map) => "arbitrary"))
+
+(facts :image-format
+  (alr/image->format "foo.webp") => "webp"
+  (alr/image->format "foo.WEBP") => "webp"
+  (alr/image->format "foo.PNG") => "png"
+  (alr/image->format "foo.jpg.PNG") => "png"
+  (alr/image->format "foo") => nil?)


### PR DESCRIPTION
Do not add the format to the options if the thumbnail extension is the same as the original. This should result in a closer mapping between legacy file names and new file names. 

There is still more work to be done to make it easier to test this, but this should at least eliminate the unnecessary addition of `[format=foo]` into the legacy filenames when no format changes are taking place.

https://wikia-inc.atlassian.net/browse/MAIN-3931

/cc @ljagiello @nmonterroso 