### PR TITLE
MAIN-3930 Check the mime time to see if it can be thumbnailed earlier in the call stack

### DIFF
--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -58,6 +58,7 @@
 
 (defn original->thumbnail
   [resource thumb-map]
+  (assert-original-mime-type resource thumb-map)
   (let [temp-file (temp-filename (str (wikia thumb-map) "_thumb"))
         base-command [thumbnail-bin
                       "--in" (.getAbsolutePath resource)

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -37,7 +37,7 @@
 (defn assert-original-mime-type
   [file thumb-map]
   (let [mime-type (mime-type-of file)]
-    (when (contains? unsupported-mime-types (mime-type-of file))
+    (when (contains? unsupported-mime-types mime-type)
       (throw+ {:type :convert-error
                :response-code 404
                :content-type mime-type
@@ -58,7 +58,6 @@
 
 (defn original->thumbnail
   [resource thumb-map]
-  (assert-original-mime-type resource thumb-map)
   (let [temp-file (temp-filename (str (wikia thumb-map) "_thumb"))
         base-command [thumbnail-bin
                       "--in" (.getAbsolutePath resource)
@@ -79,6 +78,7 @@
 
 (defn get-or-generate-thumbnail
   [system thumb-map]
+  (assert-original-mime-type (get thumb-map :original) thumb-map)
   (if-let [thumb (and (not (q/query-opt thumb-map :replace))
                       (get-thumbnail (store system) thumb-map))]
     thumb

--- a/test/vignette/util/thumbnail_test.clj
+++ b/test/vignette/util/thumbnail_test.clj
@@ -91,3 +91,8 @@
 (facts :route-map->thumb-args
        (route-map->thumb-args beach-map) => (contains ["--height" "100" "--width" "100"
                                                       "--mode" "thumbnail"] :in-any-order))
+
+(facts :assert-original-mime-type
+  (assert-original-mime-type "" {}) => nil
+  (assert-original-mime-type "file.jpg" {}) => nil
+  (assert-original-mime-type "file.ogv" {}) => (throws ExceptionInfo))


### PR DESCRIPTION
This could prevent 2 round trips to CEPH by short circuiting the thumbnailing sooner. First check the name of the original before we go to CEPH and reject it if it's unsupported. Next, check again in the original location before we attempt to thumbnail the original (this is after the original has been downloaded).

This could catch supported files that happened to be mislabeled e.g. a JPEG labeled `.ogv`. In practice I doubt this happens that often. The opposite is also true but will be handled by the current implementation. That is there could be some OGG video files with the .jpg extension. We'll still catch these when the image is on disk locally.

https://wikia-inc.atlassian.net/browse/MAIN-3930

/cc @nmonterroso @ljagiello 