### PR TITLE
Provide sane defaults for videos using mid-* in the thumbnail filename

### DIFF
--- a/src/vignette/api/legacy/routes.clj
+++ b/src/vignette/api/legacy/routes.clj
@@ -5,6 +5,8 @@
             [vignette.util.regex :refer :all])
   (:import [java.net URLDecoder]))
 
+(def default-width 200)
+
 (declare route->revision
          route->dimensions
          route->offset
@@ -12,7 +14,7 @@
          route->options)
 
 (def path-prefix-regex #"\/[/a-z-]+|")
-(def dimension-regex #"\d+px-|\d+x\d+-|\d+x\d+x\d+-|")
+(def dimension-regex #"\d+px-|\d+x\d+-|\d+x\d+x\d+-|mid-|")
 (def offset-regex #"(?i)-{0,1}\d+,\d+,-{0,1}\d+,\d+-|-{0,1}\d+%2c\d+%2c-{0,1}\d+%2c\d+-|")
 (def thumbname-regex #".*?")
 (def video-params-regex #"(?i)v,\d{6},|v%2c\d{6}%2c|")
@@ -172,6 +174,10 @@
   "Add the :width field to a request map based on the legacy parsing methods."
   (if-let [thumb-dimension (:dimension map)]
     (cond-let
+      ; this matches some legacy video requests that attempt to take the width from a frame in the "middle"
+      [_ (re-matches #"^mid-.*" thumb-dimension)] (merge map {:width default-width
+                                                              :height :auto
+                                                              :thumbnail-mode "scale-to-width"})
       [[_ dimension] (re-find #"^(\d+)px-" thumb-dimension)] (merge map {:width dimension
                                                                          :height :auto
                                                                          :thumbnail-mode "scale-to-width"})

--- a/src/vignette/util/query_options.clj
+++ b/src/vignette/util/query_options.clj
@@ -1,13 +1,15 @@
 (ns vignette.util.query-options)
 
 (defn create-query-opt
+  ([re side-effects command-line-option]
+   {:regex re :side-effects side-effects :command-line-option command-line-option})
   ([re side-effects]
-   {:regex re :side-effects side-effects})
+   (create-query-opt re side-effects false) )
   ([re]
-   (create-query-opt re true)))
+   (create-query-opt re true false)))
 
 ; regex of valid inputs for query arg
-(def query-opts-map {:fill (create-query-opt #"^#[a-g0-9]+$|^\w+$")
+(def query-opts-map {:fill (create-query-opt #"^#[a-g0-9]+$|^\w+$" true true)
                      :format (create-query-opt #"^\w+$")
                      :path-prefix (create-query-opt #"[\w\.\/-]+" false)
                      :replace (create-query-opt #"^true$" false)
@@ -25,6 +27,12 @@
   []
   (into {} (filter (fn [[k v]]
                      (= (:side-effects v) true))
+                   query-opts-map)))
+
+(defn query-opts-command-line-options
+  []
+  (into {} (filter (fn [[k v]]
+                     (= (:command-line-option v) true))
                    query-opts-map)))
 
 (defn extract-query-opts
@@ -66,7 +74,7 @@
               running))
           []
           (select-keys (query-opts data)
-                       (keys (query-opts-with-side-effects)))))
+                       (keys (query-opts-command-line-options)))))
 
 (defn modify-temp-file
   [data filename]

--- a/test/vignette/api/legacy/routes_test.clj
+++ b/test/vignette/api/legacy/routes_test.clj
@@ -20,6 +20,21 @@
     (:thumbname matched) => "SuperMario64_20.WEBP"
     (:format (:options matched)) => "webp")
 
+  (let [matched (route-matches alr/thumbnail-route
+                               (request :get "/leagueoflegends/images/thumb/3/31/Cassiopeia_RVideo.ogv/mid-Cassiopeia_RVideo.ogv.jpg"))
+        matched (alr/route->thumb-map matched)]
+    (:request-type matched) => :thumbnail
+    (alr/archive? matched) => false
+    (:original matched) => "Cassiopeia_RVideo.ogv"
+    (:middle-dir matched) => "31"
+    (:top-dir matched) => "3"
+    (:image-type matched) => "images"
+    (:width matched) => alr/default-width
+    (:wikia matched) => "leagueoflegends"
+    (:revision matched) => "latest"
+    (:thumbname matched) => "Cassiopeia_RVideo.ogv.jpg"
+    (:format (:options matched)) => "jpg")
+
   (let [matched (alr/route->thumb-map
                   (route-matches alr/thumbnail-route
                                  (request :get "/charmed/images/thumb/archive/b/b6/20101213101955!6x01-Phoebe.jpg/479px-6x01-Phoebe.jpg")))]


### PR DESCRIPTION
There are some legacy requests that attempt to thumbnail videos using `mid-<video>.ogv.jpg`. This enables sane handling of those requests with a broken image placeholder and a 404.

https://wikia-inc.atlassian.net/browse/PLATFORM-912

/cc @nmonterroso @ljagiello 