### PR TITLE
Consistent request map handling between old and new URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,21 @@ Example: [http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/zoom-crop/
 Same as the above except that the image will not be upscaled-- the original
 height and width need to be larger than those specified.
 
+### Note Regarding Legacy Compatibility
+
+Vignette also supports legacy Wikia thumbnail request URIs. This request format
+is no longer supported and is currently provided for transitional support. The
+legacy support is handled under the `*.legacy.*` namespaces.
+
+It should also be noted that there may be subtle differences between the
+thumbnails generated via the legacy and vignette URIs. For example, Legacy URLs
+and Vignette URLs calculate window width/height differently because the
+parameters to the image mean different things. In the legacy format `a,b,c,d`, `a`
+is `x-offset`, `b` is `x-endpoint` (which is not specified at all in Vignette URLs),
+and `c,d` are the same but for `y`. In Vignette URLs, we specify the `x-offset`,
+which is the same as a above, but we specify window-width instead of `x-endpoint`
+(where `window-width` is `x-endpoint - x-offset`).
+
 # License
 
 Copyright © 2014 Wikia

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -117,7 +117,7 @@
         (GET window-crop-fixed-route
              request
              (handle-thumbnail system
-                               (route->thumbnail-auto-height-map
+                               (route->thumbnail-map
                                  (:route-params request)
                                  request)))
         (GET thumbnail-route

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -86,6 +86,7 @@
          handle-original
          get-image-params
          route->offset
+         route->adjust-window-offsets
          route->thumbnail-map
          route->thumbnail-auto-height-map
          route->options

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -82,10 +82,8 @@
                   :thumbnail-mode "scale-to-width"
                   :width size-regex}))
 
-(declare image-request-handler
-         handle-thumbnail
+(declare handle-thumbnail
          handle-original
-         get-image-params
          route->offset
          route->adjust-window-offsets
          route->thumbnail-map
@@ -186,15 +184,6 @@
       (request-timer)
       (add-headers)))
 
-; TODO: remove
-(defn image-request-handler
-  [system request-type request &{:keys [thumbnail-mode height] :or {thumbnail-mode nil height nil} :as params}]
-  (let [image-params (get-image-params request request-type)
-        image-params (if params (merge image-params params) image-params)]
-    (condp = request-type
-      :thumbnail (handle-thumbnail system image-params)
-      :original (handle-original system image-params))))
-
 (defn handle-thumbnail
   [system image-params]
   (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
@@ -206,14 +195,6 @@
   (if-let [file (get-original (store system) image-params)]
     (create-image-response file image-params)
     (error-response 404 image-params)))
-
-; TODO: remove
-(defn get-image-params
-  [request request-type]
-  (let [route-params (assoc (:route-params request) :request-type request-type)
-        options (extract-query-opts request)]
-    (assoc route-params :options options
-                        :image-type (route-params->image-type route-params))))
 
 (defn route-params->image-type
   [route-params]

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -85,7 +85,6 @@
 (declare handle-thumbnail
          handle-original
          route->offset
-         route->adjust-window-offsets
          route->thumbnail-map
          route->original-map
          route->thumbnail-auto-height-map
@@ -221,7 +220,6 @@
       (assoc :request-type :thumbnail)
       (route->image-type)
       (route->options request)
-      (route->adjust-window-offsets)
       (cond->
         options (merge options))))
 
@@ -233,20 +231,3 @@
   "Extracts the query options and moves them to 'request-map'"
   [request-map request]
   (assoc request-map :options (extract-query-opts request)))
-
-(defn route->window-params-seq
-  [request-map]
-  {:pre [(map? request-map)]}
-  (let [tuple ((juxt :x-offset :window-width :y-offset :window-height) request-map)]
-    (when-not (some nil? tuple)
-      (map #(Integer. %) tuple))))
-
-(defn route->adjust-window-offsets
-  [request-map]
-  (if-let [[x-offset x-end y-offset y-end] (route->window-params-seq request-map)]
-    (let [window-width (- x-end x-offset)
-          window-height (- y-end y-offset)]
-      (-> request-map
-          (assoc :window-width (str window-width))
-          (assoc :window-height (str window-height))))
-    request-map))

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -56,13 +56,14 @@
                   :window-height size-regex}))
 
 (def window-crop-fixed-route
-  (route-compile "/:wikia:image-type/:top-dir/:middle-dir/:original/revision/:revision/window-crop-fixed/width/:width/height/:height/x-offset/:x-offset/y-offset/:y-offset/window-width/:window-width/window-height/:window-height"
+  (route-compile "/:wikia:image-type/:top-dir/:middle-dir/:original/revision/:revision/:thumbnail-mode/width/:width/height/:height/x-offset/:x-offset/y-offset/:y-offset/window-width/:window-width/window-height/:window-height"
                  {:wikia wikia-regex
                   :image-type image-type-regex
                   :top-dir top-dir-regex
                   :middle-dir middle-dir-regex
                   :original original-regex
                   :revision revision-regex
+                  :thumbnail-mode "window-crop-fixed"
                   :width size-regex
                   :height size-regex
                   :x-offset size-regex-allow-negative
@@ -116,9 +117,10 @@
                                  request)))
         (GET window-crop-fixed-route
              request
-             (image-request-handler system :thumbnail request
-                                    :thumbnail-mode "window-crop-fixed"
-                                    :height :auto))
+             (handle-thumbnail system
+                               (route->thumbnail-auto-height-map
+                                 (:route-params request)
+                                 request)))
         (GET thumbnail-route
              request
              (image-request-handler system :thumbnail request))
@@ -225,7 +227,6 @@
       (route->image-type)
       (route->options request)
       (route->adjust-window-offsets)
-      ; todo validate
       (cond->
         options (merge options))))
 

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -89,6 +89,7 @@
          route->offset
          route->adjust-window-offsets
          route->thumbnail-map
+         route->original-map
          route->thumbnail-auto-height-map
          route->options
          route-params->image-type
@@ -123,10 +124,16 @@
                                  request)))
         (GET thumbnail-route
              request
-             (image-request-handler system :thumbnail request))
+             (handle-thumbnail system
+                               (route->thumbnail-map
+                                 (:route-params request)
+                                 request)))
         (GET original-route
              request
-             (image-request-handler system :original request))
+             (handle-original system
+                              (route->original-map
+                                (:route-params request)
+                                request)))
 
         ; legacy routes
         (GET alr/thumbnail-route
@@ -219,6 +226,13 @@
 (defn route->image-type
   [request-map]
   (assoc request-map :image-type (route-params->image-type request-map)))
+
+(defn route->original-map
+  [request-map request]
+  (-> request-map
+      (assoc :request-type :original)
+      (route->image-type)
+      (route->options request)))
 
 (defn route->thumbnail-map
   [request-map request &[options]]

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -161,11 +161,13 @@
         :middle-dir "40"
         :original "JohnvanBruggen.jpg"
         :revision "latest"
+        :thumbnail-mode "window-crop"
         :width "200"
         :x-offset "0"
         :y-offset "29"
         :window-width "206"
         :window-height "103"}
+
        (route-matches window-crop-route
                       (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/-1/y-offset/29/window-width/206/window-height/103")) =>
        {:wikia "muppet"
@@ -174,6 +176,7 @@
         :middle-dir "40"
         :original "JohnvanBruggen.jpg"
         :revision "latest"
+        :thumbnail-mode "window-crop"
         :width "200"
         :x-offset "-1"
         :y-offset "29"
@@ -224,3 +227,16 @@
        (route-params->image-type {:image-type ""}) => "images"
        (route-params->image-type {:image-type "/images"}) => "images"
        (route-params->image-type {:image-type "/avatars"}) => "avatars")
+
+(facts :route->window-params-seq
+  (route->window-params-seq nil) => (throws AssertionError)
+  (route->window-params-seq {:nothing nil}) => nil
+  (route->window-params-seq {:x-offset "1"}) => nil
+  (route->window-params-seq {:x-offset "1" :window-width "100"}) => nil
+  (route->window-params-seq {:x-offset "1" :window-width "100" :y-offset "1"}) => nil
+  (route->window-params-seq {:x-offset "1" :window-width "100" :y-offset "1" :window-height "100"}) => [1 100 1 100])
+
+(facts :route->adjust-window-offsets
+  (route->adjust-window-offsets {:nothing nil}) => {:nothing nil}
+  (route->adjust-window-offsets {:x-offset "1" :window-width "100" :y-offset "1" :window-height "100"}) => {:x-offset "1" :window-width "99" :y-offset "1" :window-height "99"}
+  )

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -215,15 +215,3 @@
        (route-params->image-type {:image-type ""}) => "images"
        (route-params->image-type {:image-type "/images"}) => "images"
        (route-params->image-type {:image-type "/avatars"}) => "avatars")
-
-(facts :route->window-params-seq
-  (route->window-params-seq nil) => (throws AssertionError)
-  (route->window-params-seq {:nothing nil}) => nil
-  (route->window-params-seq {:x-offset "1"}) => nil
-  (route->window-params-seq {:x-offset "1" :window-width "100"}) => nil
-  (route->window-params-seq {:x-offset "1" :window-width "100" :y-offset "1"}) => nil
-  (route->window-params-seq {:x-offset "1" :window-width "100" :y-offset "1" :window-height "100"}) => [1 100 1 100])
-
-(facts :route->adjust-window-offsets
-  (route->adjust-window-offsets {:nothing nil}) => {:nothing nil}
-  (route->adjust-window-offsets {:x-offset "1" :window-width "100" :y-offset "1" :window-height "100"}) => {:x-offset "1" :window-width "99" :y-offset "1" :window-height "99"})

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -205,6 +205,7 @@
         :middle-dir "40"
         :original "JohnvanBruggen.jpg"
         :revision "latest"
+        :thumbnail-mode "scale-to-width"
         :width "200"})
 
 (facts :avatar-request
@@ -216,6 +217,7 @@
         :middle-dir "7c"
         :original "1271044.png"
         :revision "latest"
+        :thumbnail-mode "scale-to-width"
         :width "150"})
 
 (facts :route-params->image-type

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -13,19 +13,6 @@
             [vignette.util.thumbnail :as u])
   (:import java.io.FileNotFoundException))
 
-(facts :image-request-handler
-  (image-request-handler {} :foo {}) => (throws IllegalArgumentException)
-
-  (image-request-handler ..system.. :thumbnail ..request..) => ..response..
-  (provided
-    (get-image-params ..request.. :thumbnail) => ..params..
-    (handle-thumbnail ..system.. ..params..) => ..response..)
-
-  (image-request-handler ..system.. :original ..request..) => ..response..
-  (provided
-    (get-image-params ..request.. :original) => ..params..
-    (handle-original ..system.. ..params..) => ..response..))
-
 (facts :handle-thumbnail
   (handle-thumbnail ..system.. ..params..) => ..response..
   (provided

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -192,6 +192,7 @@
         :middle-dir "58"
         :original "Door_4.jpg"
         :revision "latest"
+        :thumbnail-mode "window-crop-fixed"
         :width "400"
         :height "400"
         :x-offset "400"
@@ -238,5 +239,4 @@
 
 (facts :route->adjust-window-offsets
   (route->adjust-window-offsets {:nothing nil}) => {:nothing nil}
-  (route->adjust-window-offsets {:x-offset "1" :window-width "100" :y-offset "1" :window-height "100"}) => {:x-offset "1" :window-width "99" :y-offset "1" :window-height "99"}
-  )
+  (route->adjust-window-offsets {:x-offset "1" :window-width "100" :y-offset "1" :window-height "100"}) => {:x-offset "1" :window-width "99" :y-offset "1" :window-height "99"})

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -102,7 +102,6 @@
                          (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.png")))]
     (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))
 
-; TODO: do the same for the other new route types that have legacy equivalents
 (facts :window-crop-thumbnail-path
   (let [new-thumbnail-map
         (r/route->thumbnail-auto-height-map

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -106,7 +106,7 @@
   (let [new-thumbnail-map
         (r/route->thumbnail-auto-height-map
           (route-matches r/window-crop-route
-                         (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/103"))
+                         (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/74"))
           {})
         legacy-thumbnail-map
         (alr/route->thumb-map
@@ -118,7 +118,7 @@
   (let [new-thumbnail-map
         (r/route->thumbnail-map
           (route-matches r/window-crop-fixed-route
-                         (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop-fixed/width/200/height/200/x-offset/0/y-offset/29/window-width/206/window-height/103"))
+                         (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop-fixed/width/200/height/200/x-offset/0/y-offset/29/window-width/206/window-height/74"))
           {})
         legacy-thumbnail-map
         (alr/route->thumb-map

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -90,12 +90,27 @@
   (original-path timeline-map) => (str "es/images/timeline/" timeline-file)
   (fully-qualified-original-path timeline-map) => (str "television/es/images/timeline/" timeline-file))
 
-(facts :scale-to-width-thumbnail
-  (let [new-thumbnail-map (r/route->scale-to-width-map
-                            (route-matches r/scale-to-width-route (request :get "/happywheels/images/b/bb/SuperMario64_20.png/revision/latest/scale-to-width/185")))
-        legacy-thumbnail-map (alr/route->thumb-map
-                               (route-matches alr/thumbnail-route
-                                              (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.png")))]
+(facts :scale-to-width-thumbnail-path
+  (let [new-thumbnail-map
+        (r/route->thumbnail-auto-height-map
+          (route-matches r/scale-to-width-route
+                         (request :get "/happywheels/images/b/bb/SuperMario64_20.png/revision/latest/scale-to-width/185"))
+          {})
+        legacy-thumbnail-map
+        (alr/route->thumb-map
+          (route-matches alr/thumbnail-route
+                         (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.png")))]
     (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))
 
 ; TODO: do the same for the other new route types that have legacy equivalents
+(facts :window-crop-thumbnail-path
+  (let [new-thumbnail-map
+        (r/route->thumbnail-auto-height-map
+          (route-matches r/window-crop-route
+                         (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/103"))
+          {})
+        legacy-thumbnail-map
+        (alr/route->thumb-map
+          (route-matches alr/thumbnail-route
+                         (request :get "/happywheels/images/thumb/4/40/JohnvanBruggen.jpg/200px-0,206,29,103-JohnvanBruggen.jpg")))]
+    (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -114,3 +114,15 @@
           (route-matches alr/thumbnail-route
                          (request :get "/happywheels/images/thumb/4/40/JohnvanBruggen.jpg/200px-0,206,29,103-JohnvanBruggen.jpg")))]
     (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))
+
+(facts :window-crop-fixed-thumbnail-path
+  (let [new-thumbnail-map
+        (r/route->thumbnail-map
+          (route-matches r/window-crop-fixed-route
+                         (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop-fixed/width/200/height/200/x-offset/0/y-offset/29/window-width/206/window-height/103"))
+          {})
+        legacy-thumbnail-map
+        (alr/route->thumb-map
+          (route-matches alr/thumbnail-route
+                         (request :get "/happywheels/images/thumb/4/40/JohnvanBruggen.jpg/200x200-0,206,29,103-JohnvanBruggen.jpg")))]
+    (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -1,5 +1,9 @@
 (ns vignette.media-types-test
   (:require [midje.sweet :refer :all]
+            [clout.core :refer (route-compile route-matches)]
+            [ring.mock.request :refer :all]
+            [vignette.http.routes :as r]
+            [vignette.api.legacy.routes :as alr]
             [vignette.media-types :refer :all]))
 
 (def original-map {:wikia "batman"
@@ -85,3 +89,13 @@
 (facts :timeline-path
   (original-path timeline-map) => (str "es/images/timeline/" timeline-file)
   (fully-qualified-original-path timeline-map) => (str "television/es/images/timeline/" timeline-file))
+
+(facts :scale-to-width-thumbnail
+  (let [new-thumbnail-map (r/route->scale-to-width-map
+                            (route-matches r/scale-to-width-route (request :get "/happywheels/images/b/bb/SuperMario64_20.png/revision/latest/scale-to-width/185")))
+        legacy-thumbnail-map (alr/route->thumb-map
+                               (route-matches alr/thumbnail-route
+                                              (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.png")))]
+    (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))
+
+; TODO: do the same for the other new route types that have legacy equivalents

--- a/test/vignette/util/external_hotlinking_test.clj
+++ b/test/vignette/util/external_hotlinking_test.clj
@@ -31,5 +31,5 @@
        (let [request (generate-request original-url)
              route-match (route-matches original-route request)
              request (assoc-in request [:route-params] route-match)
-             image-params (get-image-params request :original)]
+             image-params (route->original-map route-match request)]
          (image-params->forced-thumb-params image-params) => (contains force-thumb-params)))

--- a/test/vignette/util/image_response_test.clj
+++ b/test/vignette/util/image_response_test.clj
@@ -11,10 +11,10 @@
 
 (facts :create-image-response
   (let [image-map 
-        (get-image-params {:route-params (route-matches
-                                           original-route
-                                           (request :get "/lotr/3/35/ropes.jpg/revision/latest"))}
-                          :original)
+        (route->original-map (route-matches
+                               original-route
+                               (request :get "/lotr/3/35/ropes.jpg/revision/latest"))
+                             {})
         response (create-image-response (create-stored-object "image-samples/ropes.jpg")  image-map)
         response-headers (:headers response)]
     (get response-headers "Surrogate-Key") => "7d1d24f2c2af364882953e8c97bf90092c2f7a08"


### PR DESCRIPTION
There were a few things that stood out to me as I was working on [the duplicate file issue (PLATFORM-940)](https://wikia-inc.atlassian.net/browse/PLATFORM-940). One was that the way we handle the generation of the `image-params` was significantly different between the legacy handling and the vignette handling. The second was that I was pretty sure we were generating other duplicate files other than `[format=ext]`.

This PR addresses both issues. First, the `image-params` map generation has been made more consistent. As a result it's now possible to test that a legacy URI and a new URI that we expect to generate the same thumbnail path in fact to so. See the tests that were added. As a result, this uncovered a difference in how the parameters were being computed for the window cropping in the new style URIs. That also has been fixed.

The `image-params` generation now uses the threading macro, `->` in both cases. I find that this form is a lot more readable and it makes it easier to test the new URIs.

This conflicts with #71 but I think it's ok. I'm much happier with this code and would rather build upon this work than that to add the `HEAD` support.

/cc @nmonterroso @owend 