### PR TITLE
Refactor routes namespaces to move the helper functions out

### DIFF
--- a/.midje.clj
+++ b/.midje.clj
@@ -1,0 +1,1 @@
+(change-defaults :fact-filter (complement :thumbnail-integration))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -9,7 +9,7 @@
             [midje.repl :refer :all]
             [pantomime.mime :refer [mime-type-of]]
             [ring.mock.request :refer :all]
-            [vignette.api.legacy.routes :as alr]
+            [vignette.http.legacy.routes :as hlr]
             [vignette.http.routes :as r]
             [vignette.media-types :as mt]
             [vignette.protocols :refer :all]

--- a/project.clj
+++ b/project.clj
@@ -10,20 +10,20 @@
                  [clout "1.2.0"]
                  [compojure "1.3.1"]
                  [com.novemberain/pantomime "2.3.0"]
+                 [digest "1.4.4"]
                  [environ "0.5.0"]
                  [info.sunng/ring-jetty9-adapter "0.8.1"]
                  [ring "1.3.2"]
                  [slingshot "0.10.3"]
                  [useful "0.8.8"]
-                 [digest "1.4.4"]
                  [wikia/commons "0.1.3-SNAPSHOT"]]
   :profiles  {:dev  {:source-paths  ["dev"]
                      :plugins [[lein-midje "3.1.1"]]
-                     :dependencies  [[midje "1.6.3"]
+                     :dependencies  [[clj-http "1.0.1"]
                                      [javax.servlet/servlet-api "2.5"]
+                                     [midje "1.6.3"]
                                      [org.clojure/tools.namespace "0.2.5"]
                                      [org.clojure/tools.trace "0.7.8"]
-                                     [clj-http "1.0.1"]
                                      [ring-mock "0.1.5"]]}}
   :main vignette.core
   :aot [vignette.core

--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,7 @@
                                      [javax.servlet/servlet-api "2.5"]
                                      [org.clojure/tools.namespace "0.2.5"]
                                      [org.clojure/tools.trace "0.7.8"]
+                                     [clj-http "1.0.1"]
                                      [ring-mock "0.1.5"]]}}
   :main vignette.core
   :aot [vignette.core

--- a/src/vignette/http/legacy/route_helpers.clj
+++ b/src/vignette/http/legacy/route_helpers.clj
@@ -1,0 +1,150 @@
+(ns vignette.http.legacy.route-helpers
+  (:require [useful.experimental :refer [cond-let]]
+            [vignette.util.external-hotlinking :refer :all]
+            [vignette.protocols :refer :all]
+            [vignette.storage.protocols :refer :all]
+            [vignette.media-types :refer [archive-dir]]
+            [vignette.util.thumbnail :as u])
+  (:import [java.net URLDecoder]))
+
+(def default-width 200)
+
+(declare route->revision
+         route->dimensions
+         route->offset
+         route->thumb-mode
+         route->options
+         route->thumb-map
+         route->original-map
+         route->interactive-maps-map
+         route->interactive-maps-thumbnail-map
+         route->timeline-map
+         original-request->file)
+
+(defn archive? [map]
+  (= (:zone map) (str "/" archive-dir)))
+
+(defn zone [map]
+  (if (and (not (empty? (:zone map)))
+           (not (archive? map)))
+    (if (.startsWith (:zone map) "/")
+      (subs (:zone map) 1)
+      (:zone map))
+    nil))
+
+(defn route->thumb-map
+  [route-params]
+  ; order is important! mostly due to the different options changing :thumbnail-mode
+  (let [map (-> route-params
+                (assoc :request-type :thumbnail)
+                (assoc :thumbnail-mode "thumbnail")
+                (route->dimensions)
+                (route->offset)
+                (route->revision)
+                (route->options))]
+    map))
+
+(defn route->original-map
+  [route-params]
+  (let [map (-> route-params
+                (assoc :request-type :original)
+                (route->revision)
+                (route->options))]
+    map))
+
+(defn route->timeline-map
+  [route-params]
+  (-> route-params
+      (assoc :request-type :original)
+      (assoc :top-dir "timeline")
+      (route->options)))
+
+(defn route->interactive-maps-map
+  [route-params]
+  (-> route-params
+      (assoc :request-type :original)
+      (assoc :image-type "arbitrary")
+      (route->options)))
+
+(defn route->interactive-maps-thumbnail-map
+  [route-params]
+  (-> route-params
+      (assoc :request-type :thumbnail)
+      (assoc :image-type "arbitrary")
+      (route->dimensions)
+      (route->offset)
+      (route->options)))
+
+
+(defn route->revision
+  [map]
+  (let [revision (if (and (archive? map)
+                          (re-matches #"^\d+!.*" (:original map)))
+                   (re-find #"^\d+" (:original map))
+                   "latest")
+        map (assoc map :revision revision)]
+    (if (= revision "latest")
+      map
+      (assoc map :original (clojure.string/replace (:original map) #"^\d+!" "")))))
+
+(defn image->format
+  [file]
+  (let [[_ ext] (re-find #"(?i)\.([a-z]+)$" file)]
+    (when ext
+      (.toLowerCase ext))))
+
+(defn route->options
+  [map]
+  (let [thumb-format (image->format (get map :thumbname ""))
+        original-format (image->format (get map :original ""))
+        to-format (when (not= thumb-format original-format)
+                 thumb-format)
+        [_ path-prefix] (re-find #"^/([/a-z0-9-]+)$" (get map :path-prefix ""))
+        zone (zone map)
+        options (cond-> {}
+                     to-format (assoc :format to-format)
+                     path-prefix (assoc :path-prefix path-prefix)
+                     zone (assoc :zone zone))]
+    (assoc map :options options)))
+
+(defn route->dimensions
+  [map]
+  "Add the :width field to a request map based on the legacy parsing methods."
+  (if-let [thumb-dimension (:dimension map)]
+    (cond-let
+      ; this matches some legacy video requests that attempt to take the width from a frame in the "middle"
+      [_ (re-matches #"^mid-.*" thumb-dimension)] (merge map {:width default-width
+                                                              :height :auto
+                                                              :thumbnail-mode "scale-to-width"})
+      [[_ dimension] (re-find #"^(\d+)px-" thumb-dimension)] (merge map {:width dimension
+                                                                         :height :auto
+                                                                         :thumbnail-mode "scale-to-width"})
+      [[_ width height] (re-find #"^(\d+)x(\d+)-" thumb-dimension)] (merge map {:width width
+                                                                                :height height
+                                                                                :thumbnail-mode "fixed-aspect-ratio"})
+      [[_ width height _] (re-find #"^(\d+)x(\d+)x(\d+)-" thumb-dimension)] (merge map {:width width
+                                                                                        :height height
+                                                                                        :thumbnail-mode "zoom-crop"})
+      :else map)
+    map))
+
+(defn route->offset
+  [map]
+  (if-let [[_ x-offset x-end y-offset y-end] (re-find #"^(-{0,1}\d+),(\d+),(-{0,1}\d+),(\d+)-$"
+                                                   (URLDecoder/decode (:offset map)))]
+    (let [window-width (- (Integer. x-end) (Integer. x-offset))
+          window-height (- (Integer. y-end) (Integer. y-offset))]
+      (assoc map :thumbnail-mode (if (= (:height map) :auto)
+                                   "window-crop"
+                                   "window-crop-fixed")
+                 :x-offset x-offset
+                 :y-offset y-offset
+                 :window-width (str window-width)
+                 :window-height (str window-height)))
+    map))
+
+(defn original-request->file
+  [request system image-params]
+  (if (force-thumb? request)
+    (u/get-or-generate-thumbnail system (image-params->forced-thumb-params image-params))
+    (get-original (store system) image-params)))

--- a/src/vignette/http/legacy/routes.clj
+++ b/src/vignette/http/legacy/routes.clj
@@ -1,29 +1,12 @@
 (ns vignette.http.legacy.routes
   (:require [clout.core :refer [route-compile route-matches]]
             [compojure.core :refer [routes GET]]
-            [useful.experimental :refer [cond-let]]
-            [vignette.media-types :refer [archive-dir]]
+            [vignette.http.legacy.route-helpers :refer :all]
             [vignette.protocols :refer :all]
             [vignette.storage.protocols :refer :all]
             [vignette.util.regex :refer :all]
-            [vignette.util.external-hotlinking :refer :all]
             [vignette.util.image-response :refer :all]
-            [vignette.util.thumbnail :as u])
-  (:import [java.net URLDecoder]))
-
-(def default-width 200)
-
-(declare route->revision
-         route->dimensions
-         route->offset
-         route->thumb-mode
-         route->options
-         route->thumb-map
-         route->original-map
-         route->interactive-maps-map
-         route->interactive-maps-thumbnail-map
-         route->timeline-map
-         original-request->file)
+            [vignette.util.thumbnail :as u]))
 
 (def path-prefix-regex #"\/[/a-z-]+|")
 (def dimension-regex #"\d+px-|\d+x\d+-|\d+x\d+x\d+-|mid-|")
@@ -138,133 +121,3 @@
           (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
             (create-image-response thumb image-params)
             (error-response 404 image-params))))])
-
-
-
-(defn archive? [map]
-  (= (:zone map) (str "/" archive-dir)))
-
-(defn zone [map]
-  (if (and (not (empty? (:zone map)))
-           (not (archive? map)))
-    (if (.startsWith (:zone map) "/")
-      (subs (:zone map) 1)
-      (:zone map))
-    nil))
-
-(defn route->thumb-map
-  [route-params]
-  ; order is important! mostly due to the different options changing :thumbnail-mode
-  (let [map (-> route-params
-                (assoc :request-type :thumbnail)
-                (assoc :thumbnail-mode "thumbnail")
-                (route->dimensions)
-                (route->offset)
-                (route->revision)
-                (route->options))]
-    map))
-
-(defn route->original-map
-  [route-params]
-  (let [map (-> route-params
-                (assoc :request-type :original)
-                (route->revision)
-                (route->options))]
-    map))
-
-(defn route->timeline-map
-  [route-params]
-  (-> route-params
-      (assoc :request-type :original)
-      (assoc :top-dir "timeline")
-      (route->options)))
-
-(defn route->interactive-maps-map
-  [route-params]
-  (-> route-params
-      (assoc :request-type :original)
-      (assoc :image-type "arbitrary")
-      (route->options)))
-
-(defn route->interactive-maps-thumbnail-map
-  [route-params]
-  (-> route-params
-      (assoc :request-type :thumbnail)
-      (assoc :image-type "arbitrary")
-      (route->dimensions)
-      (route->offset)
-      (route->options)))
-
-
-(defn route->revision
-  [map]
-  (let [revision (if (and (archive? map)
-                          (re-matches #"^\d+!.*" (:original map)))
-                   (re-find #"^\d+" (:original map))
-                   "latest")
-        map (assoc map :revision revision)]
-    (if (= revision "latest")
-      map
-      (assoc map :original (clojure.string/replace (:original map) #"^\d+!" "")))))
-
-(defn image->format
-  [file]
-  (let [[_ ext] (re-find #"(?i)\.([a-z]+)$" file)]
-    (when ext
-      (.toLowerCase ext))))
-
-(defn route->options
-  [map]
-  (let [thumb-format (image->format (get map :thumbname ""))
-        original-format (image->format (get map :original ""))
-        to-format (when (not= thumb-format original-format)
-                 thumb-format)
-        [_ path-prefix] (re-find #"^/([/a-z0-9-]+)$" (get map :path-prefix ""))
-        zone (zone map)
-        options (cond-> {}
-                     to-format (assoc :format to-format)
-                     path-prefix (assoc :path-prefix path-prefix)
-                     zone (assoc :zone zone))]
-    (assoc map :options options)))
-
-(defn route->dimensions
-  [map]
-  "Add the :width field to a request map based on the legacy parsing methods."
-  (if-let [thumb-dimension (:dimension map)]
-    (cond-let
-      ; this matches some legacy video requests that attempt to take the width from a frame in the "middle"
-      [_ (re-matches #"^mid-.*" thumb-dimension)] (merge map {:width default-width
-                                                              :height :auto
-                                                              :thumbnail-mode "scale-to-width"})
-      [[_ dimension] (re-find #"^(\d+)px-" thumb-dimension)] (merge map {:width dimension
-                                                                         :height :auto
-                                                                         :thumbnail-mode "scale-to-width"})
-      [[_ width height] (re-find #"^(\d+)x(\d+)-" thumb-dimension)] (merge map {:width width
-                                                                                :height height
-                                                                                :thumbnail-mode "fixed-aspect-ratio"})
-      [[_ width height _] (re-find #"^(\d+)x(\d+)x(\d+)-" thumb-dimension)] (merge map {:width width
-                                                                                        :height height
-                                                                                        :thumbnail-mode "zoom-crop"})
-      :else map)
-    map))
-
-(defn route->offset
-  [map]
-  (if-let [[_ x-offset x-end y-offset y-end] (re-find #"^(-{0,1}\d+),(\d+),(-{0,1}\d+),(\d+)-$"
-                                                   (URLDecoder/decode (:offset map)))]
-    (let [window-width (- (Integer. x-end) (Integer. x-offset))
-          window-height (- (Integer. y-end) (Integer. y-offset))]
-      (assoc map :thumbnail-mode (if (= (:height map) :auto)
-                                   "window-crop"
-                                   "window-crop-fixed")
-                 :x-offset x-offset
-                 :y-offset y-offset
-                 :window-width (str window-width)
-                 :window-height (str window-height)))
-    map))
-
-(defn original-request->file
-  [request system image-params]
-  (if (force-thumb? request)
-    (u/get-or-generate-thumbnail system (image-params->forced-thumb-params image-params))
-    (get-original (store system) image-params)))

--- a/src/vignette/http/legacy/routes.clj
+++ b/src/vignette/http/legacy/routes.clj
@@ -1,4 +1,4 @@
-(ns vignette.api.legacy.routes
+(ns vignette.http.legacy.routes
   (:require [clout.core :refer [route-compile route-matches]]
             [useful.experimental :refer [cond-let]]
             [vignette.media-types :refer [archive-dir]]

--- a/src/vignette/http/route_helpers.clj
+++ b/src/vignette/http/route_helpers.clj
@@ -1,0 +1,57 @@
+(ns vignette.http.route-helpers
+  (:require [vignette.util.image-response :refer :all]
+            [vignette.util.query-options :refer :all]
+            [vignette.protocols :refer :all]
+            [vignette.storage.core :refer :all]
+            [vignette.storage.protocols :refer :all]
+            [vignette.util.thumbnail :as u]))
+
+
+(defn handle-thumbnail
+  [system image-params]
+  (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
+    (create-image-response thumb image-params)
+    (error-response 404 image-params)))
+
+(defn handle-original
+  [system image-params]
+  (if-let [file (get-original (store system) image-params)]
+    (create-image-response file image-params)
+    (error-response 404 image-params)))
+
+(defn route-params->image-type
+  [route-params]
+  (if (clojure.string/blank? (:image-type route-params))
+    "images"
+    (clojure.string/replace (:image-type route-params)
+                            #"^\/(.*)"
+                            "$1")))
+
+(defn route->options
+  "Extracts the query options and moves them to 'request-map'"
+  [request-map request]
+  (assoc request-map :options (extract-query-opts request)))
+
+(defn route->image-type
+  [request-map]
+  (assoc request-map :image-type (route-params->image-type request-map)))
+
+(defn route->original-map
+  [request-map request]
+  (-> request-map
+      (assoc :request-type :original)
+      (route->image-type)
+      (route->options request)))
+
+(defn route->thumbnail-map
+  [request-map request &[options]]
+  (-> request-map
+      (assoc :request-type :thumbnail)
+      (route->image-type)
+      (route->options request)
+      (cond->
+        options (merge options))))
+
+(defn route->thumbnail-auto-height-map
+  [request-map request]
+  (route->thumbnail-map request-map request {:height :auto}))

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -8,7 +8,7 @@
             [ring.middleware.params :refer [wrap-params]]
             [ring.util.response :refer [response status charset header]]
             [slingshot.slingshot :refer [try+ throw+]]
-            [vignette.api.legacy.routes :as alr]
+            [vignette.http.legacy.routes :as hlr]
             [vignette.http.middleware :refer :all]
             [vignette.protocols :refer :all]
             [vignette.storage.core :refer :all]
@@ -133,45 +133,45 @@
                                 request)))
 
         ; legacy routes
-        (GET alr/thumbnail-route
+        (GET hlr/thumbnail-route
              request
-             (let [image-params (alr/route->thumb-map (:route-params request))]
+             (let [image-params (hlr/route->thumb-map (:route-params request))]
                (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
                  (create-image-response thumb image-params)
                  (error-response 404 image-params))))
-        (GET alr/original-route
+        (GET hlr/original-route
              request
-             (let [image-params (alr/route->original-map (:route-params request))]
+             (let [image-params (hlr/route->original-map (:route-params request))]
                (if-let [file (original-request->file request system image-params)]
                  (create-image-response file image-params)
                  (error-response 404 image-params))))
-        (GET alr/timeline-route
+        (GET hlr/timeline-route
              request
-             (let [image-params (alr/route->timeline-map (:route-params request))]
+             (let [image-params (hlr/route->timeline-map (:route-params request))]
                (if-let [file (original-request->file request system image-params)]
                  (create-image-response file image-params)
                  (error-response 404 image-params))))
-        (GET alr/math-route
+        (GET hlr/math-route
              request
-             (let [image-params (alr/route->original-map (:route-params request))]
+             (let [image-params (hlr/route->original-map (:route-params request))]
                (if-let [file (original-request->file request system image-params)]
                  (create-image-response file image-params)
                  (error-response 404 image-params))))
-        (GET alr/interactive-maps-route
+        (GET hlr/interactive-maps-route
              request
-             (let [image-params (alr/route->interactive-maps-map (:route-params request))]
+             (let [image-params (hlr/route->interactive-maps-map (:route-params request))]
                (if-let [file (original-request->file request system image-params)]
                  (create-image-response file image-params)
                  (error-response 404 image-params))))
-        (GET alr/interactive-maps-marker-route
+        (GET hlr/interactive-maps-marker-route
              request
-             (let [image-params (alr/route->interactive-maps-map (:route-params request))]
+             (let [image-params (hlr/route->interactive-maps-map (:route-params request))]
                (if-let [file (original-request->file request system image-params)]
                  (create-image-response file image-params)
                  (error-response 404 image-params))))
-        (GET alr/interactive-maps-thumbnail-route
+        (GET hlr/interactive-maps-thumbnail-route
              request
-             (let [image-params (alr/route->interactive-maps-thumbnail-map (:route-params request))]
+             (let [image-params (hlr/route->interactive-maps-thumbnail-map (:route-params request))]
                (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
                  (create-image-response thumb image-params)
                  (error-response 404 image-params))))

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -10,13 +10,8 @@
             [slingshot.slingshot :refer [try+ throw+]]
             [vignette.http.legacy.routes :as hlr]
             [vignette.http.middleware :refer :all]
-            [vignette.protocols :refer :all]
-            [vignette.storage.core :refer :all]
-            [vignette.storage.protocols :refer :all]
-            [vignette.util.image-response :refer :all]
-            [vignette.util.query-options :refer :all]
-            [vignette.util.regex :refer :all]
-            [vignette.util.thumbnail :as u]))
+            [vignette.http.route-helpers :refer :all]
+            [vignette.util.regex :refer :all]))
 
 (def original-route
   (route-compile "/:wikia:image-type/:top-dir/:middle-dir/:original/revision/:revision"
@@ -81,16 +76,6 @@
                   :thumbnail-mode "scale-to-width"
                   :width size-regex}))
 
-(declare handle-thumbnail
-         handle-original
-         route->offset
-         route->thumbnail-map
-         route->original-map
-         route->thumbnail-auto-height-map
-         route->options
-         route-params->image-type
-         route->image-type)
-
 (defn app-routes
   [system]
   [(GET scale-to-width-route
@@ -137,52 +122,3 @@
       (exception-catcher)
       (request-timer)
       (add-headers)))
-
-(defn handle-thumbnail
-  [system image-params]
-  (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
-    (create-image-response thumb image-params)
-    (error-response 404 image-params)))
-
-(defn handle-original
-  [system image-params]
-  (if-let [file (get-original (store system) image-params)]
-    (create-image-response file image-params)
-    (error-response 404 image-params)))
-
-(defn route-params->image-type
-  [route-params]
-  (if (clojure.string/blank? (:image-type route-params))
-    "images"
-    (clojure.string/replace (:image-type route-params)
-                            #"^\/(.*)"
-                            "$1")))
-
-(defn route->image-type
-  [request-map]
-  (assoc request-map :image-type (route-params->image-type request-map)))
-
-(defn route->original-map
-  [request-map request]
-  (-> request-map
-      (assoc :request-type :original)
-      (route->image-type)
-      (route->options request)))
-
-(defn route->thumbnail-map
-  [request-map request &[options]]
-  (-> request-map
-      (assoc :request-type :thumbnail)
-      (route->image-type)
-      (route->options request)
-      (cond->
-        options (merge options))))
-
-(defn route->thumbnail-auto-height-map
-  [request-map request]
-  (route->thumbnail-map request-map request {:height :auto}))
-
-(defn route->options
-  "Extracts the query options and moves them to 'request-map'"
-  [request-map request]
-  (assoc request-map :options (extract-query-opts request)))

--- a/src/vignette/system.clj
+++ b/src/vignette/system.clj
@@ -1,7 +1,7 @@
 (ns vignette.system
   (:require [environ.core :refer [env]]
             [ring.adapter.jetty9 :as jetty]
-            [vignette.http.routes :refer [app-routes]]
+            [vignette.http.routes :refer [all-routes]]
             [vignette.http.jetty :refer [configure-jetty]]
             [vignette.protocols :refer :all])
   (:import [java.util.concurrent ArrayBlockingQueue]))
@@ -18,7 +18,7 @@
     (swap! (:running (:state this))
            (fn [_]
              (jetty/run-jetty
-               (app-routes this)
+               (all-routes this)
                {:port port
                 :configurator configure-jetty
                 :join? false

--- a/test/vignette/http/legacy/integration_test.clj
+++ b/test/vignette/http/legacy/integration_test.clj
@@ -2,7 +2,22 @@
   (:require [clout.core :as c]
             [midje.sweet :refer :all]
             [ring.mock.request :refer :all]
+            [digest :as digest]
+            [clj-http.client :as client]
+            [vignette.system :refer :all]
+            [vignette.protocols :refer :all]
+            [vignette.storage.local :refer [create-local-storage-system]]
+            [vignette.storage.core :refer [create-image-storage]]
+            [vignette.util.integration :refer [create-integration-env integration-path]]
             [vignette.http.legacy.routes :as hlr]))
+
+
+(create-integration-env)
+
+(def default-port 8888)
+(def los  (create-local-storage-system integration-path))
+(def lis  (create-image-storage los))
+(def system-local (create-system lis))
 
 ; parses legacy request log, spitting out URLs we don't understand
 (defn parse-request-log
@@ -25,3 +40,15 @@
 
 (facts :legacy-requests
        (parse-request-log "legacy/request.log") => (less-than 0.01))
+
+(with-state-changes [(before :facts (start system-local default-port))
+                     (after :facts (stop system-local))]
+
+  (facts :legacy-requests :integration
+    (let [response (client/get (format "http://localhost:%d/bucket/images/thumb/a/ab/beach.jpg/200px-beach.jpg" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "6f13d7df6b332e4945d90bd6785226b535f8b248"
+      (get (:headers response) "Content-Length") => "16341"
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (digest/sha1 (:body response)) => "ffd6e8e3b5fc7eb3100857f273d6d1e6e19df51c")))

--- a/test/vignette/http/legacy/integration_test.clj
+++ b/test/vignette/http/legacy/integration_test.clj
@@ -1,8 +1,8 @@
-(ns vignette.api.legacy.integration-test
+(ns vignette.http.legacy.integration-test
   (:require [clout.core :as c]
             [midje.sweet :refer :all]
             [ring.mock.request :refer :all]
-            [vignette.api.legacy.routes :as alr]))
+            [vignette.http.legacy.routes :as hlr]))
 
 ; parses legacy request log, spitting out URLs we don't understand
 (defn parse-request-log
@@ -12,8 +12,8 @@
            parse-failures []
            total-lines 0]
       (if-let [line (first lines)]
-        (if (or (and (re-find #"/thumb/" line) (c/route-matches alr/thumbnail-route (request :get line)))
-                (c/route-matches alr/original-route (request :get line)))
+        (if (or (and (re-find #"/thumb/" line) (c/route-matches hlr/thumbnail-route (request :get line)))
+                (c/route-matches hlr/original-route (request :get line)))
           (recur (rest lines) parse-failures (inc total-lines))
           (recur (rest lines) (conj parse-failures line) (inc total-lines)))
         (/ (count parse-failures) total-lines)))))

--- a/test/vignette/http/legacy/integration_test.clj
+++ b/test/vignette/http/legacy/integration_test.clj
@@ -38,13 +38,13 @@
   (fn [actual]
     (< actual max)))
 
-(facts :legacy-requests
+(facts :legacy-requests :integration
        (parse-request-log "legacy/request.log") => (less-than 0.01))
 
 (with-state-changes [(before :facts (start system-local default-port))
                      (after :facts (stop system-local))]
 
-  (facts :legacy-requests :integration
+  (facts :legacy-requests :thumbnail-integration
     (let [response (client/get (format "http://localhost:%d/bucket/images/thumb/a/ab/beach.jpg/200px-beach.jpg" default-port) {:as :byte-array})]
       (:status response) => 200
       (get (:headers response) "Surrogate-Key") => "6f13d7df6b332e4945d90bd6785226b535f8b248"

--- a/test/vignette/http/legacy/routes_test.clj
+++ b/test/vignette/http/legacy/routes_test.clj
@@ -2,14 +2,15 @@
   (:require [clout.core :refer [route-compile route-matches]]
             [midje.sweet :refer :all]
             [ring.mock.request :refer :all]
-            [vignette.http.legacy.routes :as hlr]))
+            [vignette.http.legacy.routes :refer :all]
+            [vignette.http.legacy.route-helpers :refer :all]))
 
 (facts :thumbnail-route
-  (let [matched (route-matches hlr/thumbnail-route
+  (let [matched (route-matches thumbnail-route
                                (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.WEBP"))
-        matched (hlr/route->thumb-map matched)]
+        matched (route->thumb-map matched)]
     (:request-type matched) => :thumbnail
-    (hlr/archive? matched) => false
+    (archive? matched) => false
     (:original matched) => "SuperMario64_20.png"
     (:middle-dir matched) => "bb"
     (:top-dir matched) => "b"
@@ -20,28 +21,28 @@
     (:thumbname matched) => "SuperMario64_20.WEBP"
     (:format (:options matched)) => "webp")
 
-  (let [matched (route-matches hlr/thumbnail-route
+  (let [matched (route-matches thumbnail-route
                                (request :get "/leagueoflegends/images/thumb/3/31/Cassiopeia_RVideo.ogv/mid-Cassiopeia_RVideo.ogv.jpg"))
-        matched (hlr/route->thumb-map matched)]
+        matched (route->thumb-map matched)]
     (:request-type matched) => :thumbnail
-    (hlr/archive? matched) => false
+    (archive? matched) => false
     (:original matched) => "Cassiopeia_RVideo.ogv"
     (:middle-dir matched) => "31"
     (:top-dir matched) => "3"
     (:image-type matched) => "images"
-    (:width matched) => hlr/default-width
+    (:width matched) => default-width
     (:wikia matched) => "leagueoflegends"
     (:revision matched) => "latest"
     (:thumbname matched) => "Cassiopeia_RVideo.ogv.jpg"
     (:format (:options matched)) => "jpg")
 
-  (let [matched (hlr/route->thumb-map
-                  (route-matches hlr/thumbnail-route
+  (let [matched (route->thumb-map
+                  (route-matches thumbnail-route
                                  (request :get "/charmed/images/thumb/archive/b/b6/20101213101955!6x01-Phoebe.jpg/479px-6x01-Phoebe.jpg")))]
     (:request-type matched) => :thumbnail
     (:wikia matched) => "charmed"
     (:image-type matched) => "images"
-    (hlr/archive? matched) => true
+    (archive? matched) => true
     (:top-dir matched) => "b"
     (:middle-dir matched) => "b6"
     (:original matched) => "6x01-Phoebe.jpg"
@@ -51,13 +52,13 @@
     (:thumbname matched) => "6x01-Phoebe.jpg"
     (get (:options matched) :format nil) => nil?)
 
-  (let [matched (hlr/route->thumb-map
-                  (route-matches hlr/thumbnail-route
+  (let [matched (route->thumb-map
+                  (route-matches thumbnail-route
                                  (request :get "/charmed/images/thumb/archive/b/b6/20101213101955!6x01-Phoebe.jpg/100x200x300-6x01-Phoebe.jpg")))]
     (:request-type matched) => :thumbnail
     (:wikia matched) => "charmed"
     (:image-type matched) => "images"
-    (hlr/archive? matched) => true
+    (archive? matched) => true
     (:top-dir matched) => "b"
     (:middle-dir matched) => "b6"
     (:original matched) => "6x01-Phoebe.jpg"
@@ -67,8 +68,8 @@
     (:revision matched) => "20101213101955"
     (:thumbname matched) => "6x01-Phoebe.jpg")
 
-  (let [map (hlr/route->thumb-map
-              (route-matches hlr/thumbnail-route
+  (let [map (route->thumb-map
+              (route-matches thumbnail-route
                              (request :get "/aigles-et-lys/fr/images/thumb/b/b7/Flag_of_Europe.svg/120px-Flag_of_Europe.svg.png")))]
     (:request-type map) => :thumbnail
     (:wikia map) => "aigles-et-lys"
@@ -79,11 +80,11 @@
     (:thumbname map) => "Flag_of_Europe.svg.png"
     (:path-prefix (:options map)) => "fr")
 
-  (let [matched (route-matches hlr/thumbnail-route
+  (let [matched (route-matches thumbnail-route
                                (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-0,120,0,240-SuperMario64_20.webp"))
-        matched (hlr/route->thumb-map matched)]
+        matched (route->thumb-map matched)]
     (:request-type matched) => :thumbnail
-    (hlr/archive? matched) => false
+    (archive? matched) => false
     (:original matched) => "SuperMario64_20.png"
     (:middle-dir matched) => "bb"
     (:top-dir matched) => "b"
@@ -101,9 +102,9 @@
     (:thumbnail-mode matched) => "window-crop"
     (:format (:options matched)) => "webp")
 
-  (let [matched (route-matches hlr/thumbnail-route
+  (let [matched (route-matches thumbnail-route
                                (request :get "/thelastofus/images/thumb/5/58/Door_4.jpg/400x400-400,600,200,600-Door_4.jpg"))
-        matched (hlr/route->thumb-map matched)]
+        matched (route->thumb-map matched)]
     (:thumbnail-mode matched) => "window-crop-fixed"
     (:wikia matched) => "thelastofus"
     (:top-dir matched) => "5"
@@ -116,9 +117,9 @@
     (:window-width matched) => "200"
     (:window-height matched) => "400")
 
-  (let [matched (route-matches hlr/thumbnail-route
+  (let [matched (route-matches thumbnail-route
                                (request :get "/callofduty/images/thumb/1/1f/Undone/v,000000,200px--2,480,-15,255-Undone"))
-        matched (hlr/route->thumb-map matched)]
+        matched (route->thumb-map matched)]
     (:thumbnail-mode matched) => "window-crop"
     (:wikia matched) => "callofduty"
     (:top-dir matched) => "1"
@@ -130,20 +131,20 @@
     (:window-width matched) => "482"
     (:window-height matched) => "270")
 
-  (let [matched (route-matches hlr/thumbnail-route
+  (let [matched (route-matches thumbnail-route
                                (request :get "/muppet/images/thumb/4/40/JohnvanBruggen.jpg/200px-JohnvanBruggen.jpg"))
-        matched (hlr/route->thumb-map matched)]
+        matched (route->thumb-map matched)]
     (:thumbnail-mode matched) => "scale-to-width"
     (:wikia matched) => "muppet"
     (:top-dir matched) => "4"
     (:middle-dir matched) => "40"
     (:original matched) => "JohnvanBruggen.jpg"
     (:width matched) => "200")
-  (let [matched (route-matches hlr/thumbnail-route
+  (let [matched (route-matches thumbnail-route
                                (request :get "/muppet/images/thumb/temp/4/40/JohnvanBruggen.jpg/200px-JohnvanBruggen.jpg"))
-        matched (hlr/route->thumb-map matched)]
+        matched (route->thumb-map matched)]
     (:thumbnail-mode matched) => "scale-to-width"
-    (hlr/zone matched) => "temp"
+    (zone matched) => "temp"
     (:wikia matched) => "muppet"
     (:top-dir matched) => "4"
     (:middle-dir matched) => "40"
@@ -151,8 +152,8 @@
     (:width matched) => "200"))
 
 (facts :original-route
-       (let [map (hlr/route->original-map
-                   (route-matches hlr/original-route
+       (let [map (route->original-map
+                   (route-matches original-route
                                   (request :get "/happywheels/images/b/bb/SuperMario64_20.png")))]
          (:request-type map) => :original
          (:wikia map) => "happywheels"
@@ -161,8 +162,8 @@
          (:original map) => "SuperMario64_20.png"
          (:revision map) => "latest")
 
-       (let [map (hlr/route->original-map
-                   (route-matches hlr/original-route
+       (let [map (route->original-map
+                   (route-matches original-route
                                   (request :get "/aigles-et-lys/fr/images/b/b7/Flag_of_Europe.svg")))]
          (:request-type map) => :original
          (:wikia map) => "aigles-et-lys"
@@ -171,12 +172,12 @@
          (:original map) => "Flag_of_Europe.svg"
          (:revision map) => "latest"
          (:path-prefix (:options map)) => "fr")
-       (let [map (hlr/route->original-map
-                   (route-matches hlr/original-route
+       (let [map (route->original-map
+                   (route-matches original-route
                                   (request :get "/aigles-et-lys/fr/images/temp/b/b7/Flag_of_Europe.svg")))]
          (:request-type map) => :original
          (:wikia map) => "aigles-et-lys"
-         (hlr/zone map) => "temp"
+         (zone map) => "temp"
          (:top-dir map) => "b"
          (:middle-dir map) => "b7"
          (:original map) => "Flag_of_Europe.svg"
@@ -184,8 +185,8 @@
          (:path-prefix (:options map)) => "fr"))
 
 (facts :timeline-route
-  (let [map (hlr/route->timeline-map
-              (route-matches hlr/timeline-route
+  (let [map (route->timeline-map
+              (route-matches timeline-route
                              (request :get "/television/es/images/timeline/bbe457792492f1b89f21a45aa6ca6088.png")))]
     (:request-type map) => :original
     (:top-dir map) => "timeline"
@@ -196,19 +197,19 @@
     (:image-type map) => "images"))
 
 (facts :math-route
-       (let [map (hlr/route->original-map
-                   (route-matches hlr/math-route
+       (let [map (route->original-map
+                   (route-matches math-route
                                   (request :get "/nelsontest/images/math/3/9/f/39f9e908b194691eef95b328f9abc76c.png")))]
          (:request-type map) => :original
          (:top-dir map) => "3"
          (:middle-dir map) => "9/f"
          (:original map) => "39f9e908b194691eef95b328f9abc76c.png"
-         (hlr/zone map) => "math"
+         (zone map) => "math"
          (:image-type map) => "images"))
 
 (facts :map-original-route
-  (let [map (hlr/route->interactive-maps-map
-              (route-matches hlr/interactive-maps-route
+  (let [map (route->interactive-maps-map
+              (route-matches interactive-maps-route
                            (request :get "/intmap_tile_set_4823/20150205173220!phpZDfa00.jpg")))]
     (:request-type map) => :original
     (:image-type map) => "arbitrary"
@@ -217,8 +218,8 @@
     (:wikia map) => "intmap_tile_set_4823"))
 
 (facts :map-original-route-zoom
-  (let [map (hlr/route->interactive-maps-map
-              (route-matches hlr/interactive-maps-route
+  (let [map (route->interactive-maps-map
+              (route-matches interactive-maps-route
                              (request :get "/intmap_tile_set_4692/3/1/2.png")))]
     (:request-type map) => :original
     (:image-type map) => "arbitrary"
@@ -227,8 +228,8 @@
     (:path-prefix (:options map)) => "3/1"))
 
 (facts :map-marker-route
-  (let [map (hlr/route->interactive-maps-map
-              (route-matches hlr/interactive-maps-marker-route
+  (let [map (route->interactive-maps-map
+              (route-matches interactive-maps-marker-route
                              (request :get "/intmap_markers_109/60px-20140716115821!phpZDweHO.png")))]
     (:request-type map) => :original
     (:image-type map) => "arbitrary"
@@ -237,8 +238,8 @@
     (:wikia map) => "intmap_markers_109"))
 
 (facts :map-thumbnail-route
-  (let [map (hlr/route->interactive-maps-thumbnail-map
-              (route-matches hlr/interactive-maps-thumbnail-route
+  (let [map (route->interactive-maps-thumbnail-map
+              (route-matches interactive-maps-thumbnail-route
                              (request :get "/intmap_tile_set_4823/thumb/20150205173220%21phpZDfa00.jpg/1110x300x5-20150205173220%21phpZDfa00.jpg")))]
     (:width map) => "1110"
     (:height map) => "300"
@@ -246,8 +247,8 @@
     (:image-type map) => "arbitrary"))
 
 (facts :image-format
-  (hlr/image->format "foo.webp") => "webp"
-  (hlr/image->format "foo.WEBP") => "webp"
-  (hlr/image->format "foo.PNG") => "png"
-  (hlr/image->format "foo.jpg.PNG") => "png"
-  (hlr/image->format "foo") => nil?)
+  (image->format "foo.webp") => "webp"
+  (image->format "foo.WEBP") => "webp"
+  (image->format "foo.PNG") => "png"
+  (image->format "foo.jpg.PNG") => "png"
+  (image->format "foo") => nil?)

--- a/test/vignette/http/legacy/routes_test.clj
+++ b/test/vignette/http/legacy/routes_test.clj
@@ -1,15 +1,15 @@
-(ns vignette.api.legacy.routes-test
+(ns vignette.http.legacy.routes-test
   (:require [clout.core :refer [route-compile route-matches]]
             [midje.sweet :refer :all]
             [ring.mock.request :refer :all]
-            [vignette.api.legacy.routes :as alr]))
+            [vignette.http.legacy.routes :as hlr]))
 
 (facts :thumbnail-route
-  (let [matched (route-matches alr/thumbnail-route
+  (let [matched (route-matches hlr/thumbnail-route
                                (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.WEBP"))
-        matched (alr/route->thumb-map matched)]
+        matched (hlr/route->thumb-map matched)]
     (:request-type matched) => :thumbnail
-    (alr/archive? matched) => false
+    (hlr/archive? matched) => false
     (:original matched) => "SuperMario64_20.png"
     (:middle-dir matched) => "bb"
     (:top-dir matched) => "b"
@@ -20,28 +20,28 @@
     (:thumbname matched) => "SuperMario64_20.WEBP"
     (:format (:options matched)) => "webp")
 
-  (let [matched (route-matches alr/thumbnail-route
+  (let [matched (route-matches hlr/thumbnail-route
                                (request :get "/leagueoflegends/images/thumb/3/31/Cassiopeia_RVideo.ogv/mid-Cassiopeia_RVideo.ogv.jpg"))
-        matched (alr/route->thumb-map matched)]
+        matched (hlr/route->thumb-map matched)]
     (:request-type matched) => :thumbnail
-    (alr/archive? matched) => false
+    (hlr/archive? matched) => false
     (:original matched) => "Cassiopeia_RVideo.ogv"
     (:middle-dir matched) => "31"
     (:top-dir matched) => "3"
     (:image-type matched) => "images"
-    (:width matched) => alr/default-width
+    (:width matched) => hlr/default-width
     (:wikia matched) => "leagueoflegends"
     (:revision matched) => "latest"
     (:thumbname matched) => "Cassiopeia_RVideo.ogv.jpg"
     (:format (:options matched)) => "jpg")
 
-  (let [matched (alr/route->thumb-map
-                  (route-matches alr/thumbnail-route
+  (let [matched (hlr/route->thumb-map
+                  (route-matches hlr/thumbnail-route
                                  (request :get "/charmed/images/thumb/archive/b/b6/20101213101955!6x01-Phoebe.jpg/479px-6x01-Phoebe.jpg")))]
     (:request-type matched) => :thumbnail
     (:wikia matched) => "charmed"
     (:image-type matched) => "images"
-    (alr/archive? matched) => true
+    (hlr/archive? matched) => true
     (:top-dir matched) => "b"
     (:middle-dir matched) => "b6"
     (:original matched) => "6x01-Phoebe.jpg"
@@ -51,13 +51,13 @@
     (:thumbname matched) => "6x01-Phoebe.jpg"
     (get (:options matched) :format nil) => nil?)
 
-  (let [matched (alr/route->thumb-map
-                  (route-matches alr/thumbnail-route
+  (let [matched (hlr/route->thumb-map
+                  (route-matches hlr/thumbnail-route
                                  (request :get "/charmed/images/thumb/archive/b/b6/20101213101955!6x01-Phoebe.jpg/100x200x300-6x01-Phoebe.jpg")))]
     (:request-type matched) => :thumbnail
     (:wikia matched) => "charmed"
     (:image-type matched) => "images"
-    (alr/archive? matched) => true
+    (hlr/archive? matched) => true
     (:top-dir matched) => "b"
     (:middle-dir matched) => "b6"
     (:original matched) => "6x01-Phoebe.jpg"
@@ -67,8 +67,8 @@
     (:revision matched) => "20101213101955"
     (:thumbname matched) => "6x01-Phoebe.jpg")
 
-  (let [map (alr/route->thumb-map
-              (route-matches alr/thumbnail-route
+  (let [map (hlr/route->thumb-map
+              (route-matches hlr/thumbnail-route
                              (request :get "/aigles-et-lys/fr/images/thumb/b/b7/Flag_of_Europe.svg/120px-Flag_of_Europe.svg.png")))]
     (:request-type map) => :thumbnail
     (:wikia map) => "aigles-et-lys"
@@ -79,11 +79,11 @@
     (:thumbname map) => "Flag_of_Europe.svg.png"
     (:path-prefix (:options map)) => "fr")
 
-  (let [matched (route-matches alr/thumbnail-route
+  (let [matched (route-matches hlr/thumbnail-route
                                (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-0,120,0,240-SuperMario64_20.webp"))
-        matched (alr/route->thumb-map matched)]
+        matched (hlr/route->thumb-map matched)]
     (:request-type matched) => :thumbnail
-    (alr/archive? matched) => false
+    (hlr/archive? matched) => false
     (:original matched) => "SuperMario64_20.png"
     (:middle-dir matched) => "bb"
     (:top-dir matched) => "b"
@@ -101,9 +101,9 @@
     (:thumbnail-mode matched) => "window-crop"
     (:format (:options matched)) => "webp")
 
-  (let [matched (route-matches alr/thumbnail-route
+  (let [matched (route-matches hlr/thumbnail-route
                                (request :get "/thelastofus/images/thumb/5/58/Door_4.jpg/400x400-400,600,200,600-Door_4.jpg"))
-        matched (alr/route->thumb-map matched)]
+        matched (hlr/route->thumb-map matched)]
     (:thumbnail-mode matched) => "window-crop-fixed"
     (:wikia matched) => "thelastofus"
     (:top-dir matched) => "5"
@@ -116,9 +116,9 @@
     (:window-width matched) => "200"
     (:window-height matched) => "400")
 
-  (let [matched (route-matches alr/thumbnail-route
+  (let [matched (route-matches hlr/thumbnail-route
                                (request :get "/callofduty/images/thumb/1/1f/Undone/v,000000,200px--2,480,-15,255-Undone"))
-        matched (alr/route->thumb-map matched)]
+        matched (hlr/route->thumb-map matched)]
     (:thumbnail-mode matched) => "window-crop"
     (:wikia matched) => "callofduty"
     (:top-dir matched) => "1"
@@ -130,20 +130,20 @@
     (:window-width matched) => "482"
     (:window-height matched) => "270")
 
-  (let [matched (route-matches alr/thumbnail-route
+  (let [matched (route-matches hlr/thumbnail-route
                                (request :get "/muppet/images/thumb/4/40/JohnvanBruggen.jpg/200px-JohnvanBruggen.jpg"))
-        matched (alr/route->thumb-map matched)]
+        matched (hlr/route->thumb-map matched)]
     (:thumbnail-mode matched) => "scale-to-width"
     (:wikia matched) => "muppet"
     (:top-dir matched) => "4"
     (:middle-dir matched) => "40"
     (:original matched) => "JohnvanBruggen.jpg"
     (:width matched) => "200")
-  (let [matched (route-matches alr/thumbnail-route
+  (let [matched (route-matches hlr/thumbnail-route
                                (request :get "/muppet/images/thumb/temp/4/40/JohnvanBruggen.jpg/200px-JohnvanBruggen.jpg"))
-        matched (alr/route->thumb-map matched)]
+        matched (hlr/route->thumb-map matched)]
     (:thumbnail-mode matched) => "scale-to-width"
-    (alr/zone matched) => "temp"
+    (hlr/zone matched) => "temp"
     (:wikia matched) => "muppet"
     (:top-dir matched) => "4"
     (:middle-dir matched) => "40"
@@ -151,8 +151,8 @@
     (:width matched) => "200"))
 
 (facts :original-route
-       (let [map (alr/route->original-map
-                   (route-matches alr/original-route
+       (let [map (hlr/route->original-map
+                   (route-matches hlr/original-route
                                   (request :get "/happywheels/images/b/bb/SuperMario64_20.png")))]
          (:request-type map) => :original
          (:wikia map) => "happywheels"
@@ -161,8 +161,8 @@
          (:original map) => "SuperMario64_20.png"
          (:revision map) => "latest")
 
-       (let [map (alr/route->original-map
-                   (route-matches alr/original-route
+       (let [map (hlr/route->original-map
+                   (route-matches hlr/original-route
                                   (request :get "/aigles-et-lys/fr/images/b/b7/Flag_of_Europe.svg")))]
          (:request-type map) => :original
          (:wikia map) => "aigles-et-lys"
@@ -171,12 +171,12 @@
          (:original map) => "Flag_of_Europe.svg"
          (:revision map) => "latest"
          (:path-prefix (:options map)) => "fr")
-       (let [map (alr/route->original-map
-                   (route-matches alr/original-route
+       (let [map (hlr/route->original-map
+                   (route-matches hlr/original-route
                                   (request :get "/aigles-et-lys/fr/images/temp/b/b7/Flag_of_Europe.svg")))]
          (:request-type map) => :original
          (:wikia map) => "aigles-et-lys"
-         (alr/zone map) => "temp"
+         (hlr/zone map) => "temp"
          (:top-dir map) => "b"
          (:middle-dir map) => "b7"
          (:original map) => "Flag_of_Europe.svg"
@@ -184,8 +184,8 @@
          (:path-prefix (:options map)) => "fr"))
 
 (facts :timeline-route
-  (let [map (alr/route->timeline-map
-              (route-matches alr/timeline-route
+  (let [map (hlr/route->timeline-map
+              (route-matches hlr/timeline-route
                              (request :get "/television/es/images/timeline/bbe457792492f1b89f21a45aa6ca6088.png")))]
     (:request-type map) => :original
     (:top-dir map) => "timeline"
@@ -196,19 +196,19 @@
     (:image-type map) => "images"))
 
 (facts :math-route
-       (let [map (alr/route->original-map
-                   (route-matches alr/math-route
+       (let [map (hlr/route->original-map
+                   (route-matches hlr/math-route
                                   (request :get "/nelsontest/images/math/3/9/f/39f9e908b194691eef95b328f9abc76c.png")))]
          (:request-type map) => :original
          (:top-dir map) => "3"
          (:middle-dir map) => "9/f"
          (:original map) => "39f9e908b194691eef95b328f9abc76c.png"
-         (alr/zone map) => "math"
+         (hlr/zone map) => "math"
          (:image-type map) => "images"))
 
 (facts :map-original-route
-  (let [map (alr/route->interactive-maps-map
-              (route-matches alr/interactive-maps-route
+  (let [map (hlr/route->interactive-maps-map
+              (route-matches hlr/interactive-maps-route
                            (request :get "/intmap_tile_set_4823/20150205173220!phpZDfa00.jpg")))]
     (:request-type map) => :original
     (:image-type map) => "arbitrary"
@@ -217,8 +217,8 @@
     (:wikia map) => "intmap_tile_set_4823"))
 
 (facts :map-original-route-zoom
-  (let [map (alr/route->interactive-maps-map
-              (route-matches alr/interactive-maps-route
+  (let [map (hlr/route->interactive-maps-map
+              (route-matches hlr/interactive-maps-route
                              (request :get "/intmap_tile_set_4692/3/1/2.png")))]
     (:request-type map) => :original
     (:image-type map) => "arbitrary"
@@ -227,8 +227,8 @@
     (:path-prefix (:options map)) => "3/1"))
 
 (facts :map-marker-route
-  (let [map (alr/route->interactive-maps-map
-              (route-matches alr/interactive-maps-marker-route
+  (let [map (hlr/route->interactive-maps-map
+              (route-matches hlr/interactive-maps-marker-route
                              (request :get "/intmap_markers_109/60px-20140716115821!phpZDweHO.png")))]
     (:request-type map) => :original
     (:image-type map) => "arbitrary"
@@ -237,8 +237,8 @@
     (:wikia map) => "intmap_markers_109"))
 
 (facts :map-thumbnail-route
-  (let [map (alr/route->interactive-maps-thumbnail-map
-              (route-matches alr/interactive-maps-thumbnail-route
+  (let [map (hlr/route->interactive-maps-thumbnail-map
+              (route-matches hlr/interactive-maps-thumbnail-route
                              (request :get "/intmap_tile_set_4823/thumb/20150205173220%21phpZDfa00.jpg/1110x300x5-20150205173220%21phpZDfa00.jpg")))]
     (:width map) => "1110"
     (:height map) => "300"
@@ -246,8 +246,8 @@
     (:image-type map) => "arbitrary"))
 
 (facts :image-format
-  (alr/image->format "foo.webp") => "webp"
-  (alr/image->format "foo.WEBP") => "webp"
-  (alr/image->format "foo.PNG") => "png"
-  (alr/image->format "foo.jpg.PNG") => "png"
-  (alr/image->format "foo") => nil?)
+  (hlr/image->format "foo.webp") => "webp"
+  (hlr/image->format "foo.WEBP") => "webp"
+  (hlr/image->format "foo.PNG") => "png"
+  (hlr/image->format "foo.jpg.PNG") => "png"
+  (hlr/image->format "foo") => nil?)

--- a/test/vignette/http/route_helpers_test.clj
+++ b/test/vignette/http/route_helpers_test.clj
@@ -1,0 +1,40 @@
+(ns vignette.http.route-helpers-test
+  (:require [clojure.java.io :as io]
+            [clout.core :refer (route-compile route-matches)]
+            [midje.sweet :refer :all]
+            [vignette.http.route-helpers :refer :all]
+            [vignette.protocols :refer :all]
+            [vignette.util.image-response :refer :all]
+            [vignette.storage.protocols :as sp]
+            [vignette.util.image-response :as ir]
+            [vignette.util.thumbnail :as u])
+  (:import java.io.FileNotFoundException))
+
+(facts :handle-thumbnail
+  (handle-thumbnail ..system.. ..params..) => ..response..
+  (provided
+    (u/get-or-generate-thumbnail ..system.. ..params..) => ..thumb..
+    (create-image-response ..thumb.. ..params..) => ..response..)
+
+  (handle-thumbnail ..system.. ..params..) => ..error..
+  (provided
+    (u/get-or-generate-thumbnail ..system.. ..params..) => nil
+    (error-response 404 ..params..) => ..error..))
+
+(facts :handle-original
+  (handle-original ..system.. ..params..) => ..response..
+  (provided
+    (store ..system..) => ..store..
+    (sp/get-original ..store.. ..params..) => ..original..
+    (create-image-response ..original.. ..params..) => ..response..)
+
+  (handle-original ..system.. ..params..) => ..error..
+  (provided
+    (store ..system..) => ..store..
+    (sp/get-original ..store.. ..params..) => nil
+    (error-response 404 ..params..) => ..error..))
+
+(facts :route-params->image-type
+       (route-params->image-type {:image-type ""}) => "images"
+       (route-params->image-type {:image-type "/images"}) => "images"
+       (route-params->image-type {:image-type "/avatars"}) => "avatars")

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -13,30 +13,6 @@
             [vignette.util.thumbnail :as u])
   (:import java.io.FileNotFoundException))
 
-(facts :handle-thumbnail
-  (handle-thumbnail ..system.. ..params..) => ..response..
-  (provided
-    (u/get-or-generate-thumbnail ..system.. ..params..) => ..thumb..
-    (create-image-response ..thumb.. ..params..) => ..response..)
-
-  (handle-thumbnail ..system.. ..params..) => ..error..
-  (provided
-    (u/get-or-generate-thumbnail ..system.. ..params..) => nil
-    (error-response 404 ..params..) => ..error..))
-
-(facts :handle-original
-  (handle-original ..system.. ..params..) => ..response..
-  (provided
-    (store ..system..) => ..store..
-    (sp/get-original ..store.. ..params..) => ..original..
-    (create-image-response ..original.. ..params..) => ..response..)
-
-  (handle-original ..system.. ..params..) => ..error..
-  (provided
-    (store ..system..) => ..store..
-    (sp/get-original ..store.. ..params..) => nil
-    (error-response 404 ..params..) => ..error..))
-
 (facts :original-route
   (route-matches original-route (request :get "/swift/v1")) => falsey
   (route-matches
@@ -210,8 +186,3 @@
         :revision "latest"
         :thumbnail-mode "scale-to-width"
         :width "150"})
-
-(facts :route-params->image-type
-       (route-params->image-type {:image-type ""}) => "images"
-       (route-params->image-type {:image-type "/images"}) => "images"
-       (route-params->image-type {:image-type "/avatars"}) => "avatars")

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -85,10 +85,10 @@
                                             :width "10"
                                             :height "10"}))
 
-(facts :app-routes
-  ((app-routes nil) (request :get "/not-a-valid-route")) => (contains {:status 404}))
+(facts :all-routes
+  ((all-routes nil) (request :get "/not-a-valid-route")) => (contains {:status 404}))
 
-(facts :app-routes-thumbnail
+(facts :all-routes-thumbnail
   (let [route-params {:request-type :thumbnail
                       :image-type "images"
                       :original "ropes.jpg"
@@ -100,21 +100,21 @@
                       :height "10"
                       :width "10"
                       :options {}}]
-    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/latest/thumbnail/width/10/height/10")) => (contains {:status 200})
+    ((all-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/latest/thumbnail/width/10/height/10")) => (contains {:status 200})
     (provided
      (u/get-or-generate-thumbnail ..system.. route-params) => (ls/create-stored-object (io/file "image-samples/ropes.jpg")))
 
-    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/latest/thumbnail/width/10/height/10")) => (contains {:status 404})
+    ((all-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/latest/thumbnail/width/10/height/10")) => (contains {:status 404})
     (provided
      (u/get-or-generate-thumbnail ..system.. route-params) => nil
      (ir/error-image route-params) => ..thumb..
      (ir/create-image-response ..thumb.. route-params) => {})
 
-    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/latest/thumbnail/width/10/height/10")) => (contains {:status 500})
+    ((all-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/latest/thumbnail/width/10/height/10")) => (contains {:status 500})
     (provided
       (u/get-or-generate-thumbnail ..system.. route-params) =throws=> (NullPointerException.))))
 
-(facts :app-routes-original
+(facts :all-routes-original
 
   (let [route-params {:request-type :original
                       :image-type "images"
@@ -124,17 +124,17 @@
                       :revision "12345"
                       :wikia "lotr"
                       :options {}} ]
-    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/12345")) => (contains {:status 200})
+    ((all-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/12345")) => (contains {:status 200})
     (provided
      (store ..system..) => ..store..
      (sp/get-original ..store.. route-params) => (ls/create-stored-object (io/file "image-samples/ropes.jpg")))
 
-    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/12345")) => (contains {:status 404})
+    ((all-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/12345")) => (contains {:status 404})
     (provided
      (store ..system..) => ..store..
      (sp/get-original ..store.. route-params) => nil)
 
-    ((app-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/12345")) => (contains {:status 500})
+    ((all-routes ..system..) (request :get "/lotr/3/35/ropes.jpg/revision/12345")) => (contains {:status 500})
     (provided
       (store ..system..) => ..store..
       (sp/get-original ..store.. route-params) =throws=> (NullPointerException.))))

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -3,7 +3,7 @@
             [clout.core :refer (route-compile route-matches)]
             [ring.mock.request :refer :all]
             [vignette.http.routes :as r]
-            [vignette.api.legacy.routes :as alr]
+            [vignette.http.legacy.routes :as hlr]
             [vignette.media-types :refer :all]))
 
 (def original-map {:wikia "batman"
@@ -97,8 +97,8 @@
                          (request :get "/happywheels/images/b/bb/SuperMario64_20.png/revision/latest/scale-to-width/185"))
           {})
         legacy-thumbnail-map
-        (alr/route->thumb-map
-          (route-matches alr/thumbnail-route
+        (hlr/route->thumb-map
+          (route-matches hlr/thumbnail-route
                          (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.png")))]
     (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))
 
@@ -109,8 +109,8 @@
                          (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/74"))
           {})
         legacy-thumbnail-map
-        (alr/route->thumb-map
-          (route-matches alr/thumbnail-route
+        (hlr/route->thumb-map
+          (route-matches hlr/thumbnail-route
                          (request :get "/happywheels/images/thumb/4/40/JohnvanBruggen.jpg/200px-0,206,29,103-JohnvanBruggen.jpg")))]
     (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))
 
@@ -121,7 +121,7 @@
                          (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop-fixed/width/200/height/200/x-offset/0/y-offset/29/window-width/206/window-height/74"))
           {})
         legacy-thumbnail-map
-        (alr/route->thumb-map
-          (route-matches alr/thumbnail-route
+        (hlr/route->thumb-map
+          (route-matches hlr/thumbnail-route
                          (request :get "/happywheels/images/thumb/4/40/JohnvanBruggen.jpg/200x200-0,206,29,103-JohnvanBruggen.jpg")))]
     (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -5,6 +5,7 @@
             [vignette.http.routes :as r]
             [vignette.http.route-helpers :as rh]
             [vignette.http.legacy.routes :as hlr]
+            [vignette.http.legacy.route-helpers :as hlrh]
             [vignette.media-types :refer :all]))
 
 (def original-map {:wikia "batman"
@@ -98,7 +99,7 @@
                          (request :get "/happywheels/images/b/bb/SuperMario64_20.png/revision/latest/scale-to-width/185"))
           {})
         legacy-thumbnail-map
-        (hlr/route->thumb-map
+        (hlrh/route->thumb-map
           (route-matches hlr/thumbnail-route
                          (request :get "/happywheels/images/thumb/b/bb/SuperMario64_20.png/185px-SuperMario64_20.png")))]
     (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))
@@ -110,7 +111,7 @@
                          (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/74"))
           {})
         legacy-thumbnail-map
-        (hlr/route->thumb-map
+        (hlrh/route->thumb-map
           (route-matches hlr/thumbnail-route
                          (request :get "/happywheels/images/thumb/4/40/JohnvanBruggen.jpg/200px-0,206,29,103-JohnvanBruggen.jpg")))]
     (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))
@@ -122,7 +123,7 @@
                          (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop-fixed/width/200/height/200/x-offset/0/y-offset/29/window-width/206/window-height/74"))
           {})
         legacy-thumbnail-map
-        (hlr/route->thumb-map
+        (hlrh/route->thumb-map
           (route-matches hlr/thumbnail-route
                          (request :get "/happywheels/images/thumb/4/40/JohnvanBruggen.jpg/200x200-0,206,29,103-JohnvanBruggen.jpg")))]
     (thumbnail-path new-thumbnail-map) => (thumbnail-path legacy-thumbnail-map)))

--- a/test/vignette/media_types_test.clj
+++ b/test/vignette/media_types_test.clj
@@ -3,6 +3,7 @@
             [clout.core :refer (route-compile route-matches)]
             [ring.mock.request :refer :all]
             [vignette.http.routes :as r]
+            [vignette.http.route-helpers :as rh]
             [vignette.http.legacy.routes :as hlr]
             [vignette.media-types :refer :all]))
 
@@ -92,7 +93,7 @@
 
 (facts :scale-to-width-thumbnail-path
   (let [new-thumbnail-map
-        (r/route->thumbnail-auto-height-map
+        (rh/route->thumbnail-auto-height-map
           (route-matches r/scale-to-width-route
                          (request :get "/happywheels/images/b/bb/SuperMario64_20.png/revision/latest/scale-to-width/185"))
           {})
@@ -104,7 +105,7 @@
 
 (facts :window-crop-thumbnail-path
   (let [new-thumbnail-map
-        (r/route->thumbnail-auto-height-map
+        (rh/route->thumbnail-auto-height-map
           (route-matches r/window-crop-route
                          (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop/width/200/x-offset/0/y-offset/29/window-width/206/window-height/74"))
           {})
@@ -116,7 +117,7 @@
 
 (facts :window-crop-fixed-thumbnail-path
   (let [new-thumbnail-map
-        (r/route->thumbnail-map
+        (rh/route->thumbnail-map
           (route-matches r/window-crop-fixed-route
                          (request :get "/muppet/images/4/40/JohnvanBruggen.jpg/revision/latest/window-crop-fixed/width/200/height/200/x-offset/0/y-offset/29/window-width/206/window-height/74"))
           {})

--- a/test/vignette/util/external_hotlinking_test.clj
+++ b/test/vignette/util/external_hotlinking_test.clj
@@ -3,6 +3,7 @@
             [midje.sweet :refer :all]
             [ring.mock.request :refer :all]
             [vignette.http.routes :refer :all]
+            [vignette.http.route-helpers :refer :all]
             [vignette.util.external-hotlinking :refer :all]))
 
 (def original-url "/wikiaglobal/images/5/58/Wikia-Visualization-Main,croatiaempire.png/revision/latest")

--- a/test/vignette/util/image_response_test.clj
+++ b/test/vignette/util/image_response_test.clj
@@ -3,6 +3,7 @@
            [clout.core :refer (route-compile route-matches)]
            [midje.sweet :refer :all]
            [ring.mock.request :refer :all]
+           [vignette.http.route-helpers :refer :all]
            [vignette.http.routes :refer :all]
            [vignette.util.image-response :refer :all]
            [vignette.storage.core :refer :all]


### PR DESCRIPTION
This is a follow-up to the feedback [here](https://github.com/Wikia/vignette/pull/75#discussion_r25633018).

This PR attempts to simplify our routing namespaces by moving the helper functions out into a separate namespace. This should reduce the clutter and make the main `http.routes` namespace more cohesive.

I also started an experiment with a very simple integration test to see if it works in travis. If it does we can add more to make sure that the API remains stable and ensure that the correct headers are in place. I think our test coverage is decent, but insufficient when making changes that affect the outermost part of the request stack like the handler as in the case with this PR.

/cc @nmonterroso 