### PR TITLE
PLATFORM-826 Add head support & integration tests for vignette routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A Clojure library for thumbnail generation and storage.
             - [zoom-crop](#zoom-crop)
             - [zoom-crop-down](#zoom-crop-down)
         - [Note Regarding Legacy Compatibility](#note-regarding-legacy-compatibility)
+    - [Other HTTP Methods Supported](#other-http-methods-supported)
+        - [HEAD](#head)
 - [License](#license)
 - [Contributors](#contributors)
 
@@ -226,6 +228,15 @@ is `x-offset`, `b` is `x-endpoint` (which is not specified at all in Vignette UR
 and `c,d` are the same but for `y`. In Vignette URLs, we specify the `x-offset`,
 which is the same as a above, but we specify window-width instead of `x-endpoint`
 (where `window-width` is `x-endpoint - x-offset`).
+
+## Other HTTP Methods Supported
+
+### HEAD
+
+Limited support for `HEAD` is provided. Given that any request for an
+object will need to go to storage `HEAD` requests currently only check for
+object existence. As a result, `HEAD` requests will not include the
+`Content-Type` in the response.
 
 # License
 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -64,12 +64,13 @@
   )
 
 (defn re-init-dev
-  ([port]
+  ([s port]
    (do
-     (stop system-s3)
-     (start system-s3 port)))
+     (stop s)
+     (start s port)))
   ([]
-   (re-init-dev 8080)))
+   (re-init-dev system-local 8080)))
+
 
 (defn mime-stats [path]
   (defn benchmark [file]

--- a/src/vignette/http/route_helpers.clj
+++ b/src/vignette/http/route_helpers.clj
@@ -19,6 +19,12 @@
     (create-image-response file image-params)
     (error-response 404 image-params)))
 
+(defn handle-head
+  [system image-params]
+  (if (original-exists? (store system) image-params)
+    (create-head-response image-params)
+    (error-response 404 image-params)))
+
 (defn route-params->image-type
   [route-params]
   (if (clojure.string/blank? (:image-type route-params))

--- a/src/vignette/storage/core.clj
+++ b/src/vignette/storage/core.clj
@@ -20,6 +20,12 @@
               (mt/wikia object-map)
               (get-path object-map)))
 
+(defn exists?
+  [store object-map get-path]
+  (object-exists? store
+                  (mt/wikia object-map)
+                  (get-path object-map)))
+
 (defrecord ImageStorage [store]
   ImageStorageProtocol
 
@@ -43,7 +49,12 @@
   (get-original [this original-map]
     (get* (:store this)
           original-map
-          mt/original-path)))
+          mt/original-path))
+
+  (original-exists? [this image-map]
+    (exists? (:store this)
+             image-map
+             mt/original-path)))
 
 (defn create-image-storage
   [store]

--- a/src/vignette/storage/local.clj
+++ b/src/vignette/storage/local.clj
@@ -32,6 +32,10 @@
          false
          true))))
 
+  (object-exists? [this bucket path]
+    (let [real-file (io/file (resolve-local-path (:directory this) bucket path))]
+      (file-exists? real-file)))
+
   (list-buckets [this])
   (list-objects [this bucket]))
 

--- a/src/vignette/storage/protocols.clj
+++ b/src/vignette/storage/protocols.clj
@@ -4,6 +4,7 @@
   (get-object [this bucket path])
   (put-object [this resource bucket path])
   (delete-object [this bucket path])
+  (object-exists? [this bucket path])
   (list-buckets [this])
   (list-objects [this bucket]))
 
@@ -12,7 +13,8 @@
   (get-thumbnail [this thumb-map])
 
   (save-original  [this resource original-map])
-  (get-original  [this original-map]))
+  (get-original  [this original-map])
+  (original-exists? [this image-map]))
 
 (defprotocol StoredObjectProtocol
   (file-stream [this])

--- a/src/vignette/storage/s3.clj
+++ b/src/vignette/storage/s3.clj
@@ -101,6 +101,10 @@
                                                               {:content-type mime-type}))]
         response)))
   (delete-object [this bucket path])
+  (object-exists? [this bucket path]
+    (s3/object-exists? (add-timeouts :head (:creds this))
+                       bucket
+                       path))
   (list-buckets [this])
   (list-objects [this bucket]))
 

--- a/test/vignette/http/integration_test.clj
+++ b/test/vignette/http/integration_test.clj
@@ -1,0 +1,112 @@
+(ns vignette.http.integration-test
+  (:require [midje.sweet :refer :all]
+            [digest :as digest]
+            [clj-http.client :as client]
+            [vignette.system :refer :all]
+            [vignette.protocols :refer :all]
+            [vignette.storage.local :refer [create-local-storage-system]]
+            [vignette.storage.core :refer [create-image-storage]]
+            [vignette.util.integration :refer [create-integration-env integration-path]]))
+
+(create-integration-env)
+
+(def default-port 8888)
+(def los  (create-local-storage-system integration-path))
+(def lis  (create-image-storage los))
+(def system-local (create-system lis))
+
+(with-state-changes [(before :facts (start system-local default-port))
+                     (after :facts (stop system-local))]
+
+  (facts :requests :thumbnail-integration :scale-to-width
+    (let [response (client/get (format "http://localhost:8080/bucket/a/ab/boat.jpg/revision/latest/scale-to-width/200" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "6991f130a508cf3d03f8f097c32b0ff11beb5b77"
+      (get (:headers response) "Content-Disposition") => "inline; filename=\"boat.jpg\""
+      (get (:headers response) "Content-Length") => "8959"
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (digest/sha1 (:body response)) => "8cda222a0fe951145839412322810ce3c946d880")
+
+    (let [response (client/head (format "http://localhost:8080/bucket/a/ab/boat.jpg/revision/latest/scale-to-width/200" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "6991f130a508cf3d03f8f097c32b0ff11beb5b77"
+      (get (:headers response) "Content-Disposition") => "inline; filename=\"boat.jpg\""
+      (get (:headers response) "Content-Length") => nil?
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (:body response) => nil?)) 
+
+  (facts :requests :thumbnail-integration :window-crop
+    (let [response (client/get (format "http://localhost:8080/bucket/a/ab/carousel.jpg/revision/latest/window-crop/width/200/x-offset/690/y-offset/250/window-width/1600/window-height/1900" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "e0b7c4db3fb0453950367c1703710925b649babb"
+      (get (:headers response) "Content-Disposition") => "inline; filename=\"carousel.jpg\""
+      (get (:headers response) "Content-Length") => "23175"
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (digest/sha1 (:body response)) => "2c44b2eace007623148ee8a33d0f66f4ea1b0175")
+
+    (let [response (client/head (format "http://localhost:8080/bucket/a/ab/carousel.jpg/revision/latest/window-crop/width/200/x-offset/690/y-offset/250/window-width/1600/window-height/1900" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "e0b7c4db3fb0453950367c1703710925b649babb"
+      (get (:headers response) "Content-Disposition") => "inline; filename=\"carousel.jpg\""
+      (get (:headers response) "Content-Length") => nil?
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (:body response) => nil?)) 
+
+  (facts :requests :thumbnail-integration :window-crop-fixed
+    (let [response (client/get (format "http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/window-crop-fixed/width/200/height/200/x-offset/60/y-offset/550/window-width/200/window-height/260?fill=blue" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "6f13d7df6b332e4945d90bd6785226b535f8b248"
+      (get (:headers response) "Content-Disposition") => "inline; filename=\"beach.jpg\""
+      (get (:headers response) "Content-Length") => "9600"
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (digest/sha1 (:body response)) => "3f00690095caced27fdf2957f6b58929228d1326")
+
+    (let [response (client/head (format "http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/window-crop-fixed/width/200/height/200/x-offset/60/y-offset/550/window-width/200/window-height/260?fill=blue" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "6f13d7df6b332e4945d90bd6785226b535f8b248"
+      (get (:headers response) "Content-Disposition") => "inline; filename=\"beach.jpg\""
+      (get (:headers response) "Content-Length") => nil?
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (:body response) => nil?)) 
+
+  (facts :requests :thumbnail-integration :fixed-aspect-ratio :thumbnail
+    (let [response (client/get (format "http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/fixed-aspect-ratio/width/200/height/200?fill=blue" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "6f13d7df6b332e4945d90bd6785226b535f8b248"
+      (get (:headers response) "Content-Length") => "9447"
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (digest/sha1 (:body response)) => "bc34c07703035ae131aeb5615b45ea3eae7b82ba")
+
+    (let [response (client/head (format "http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest/fixed-aspect-ratio/width/200/height/200?fill=blue" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "6f13d7df6b332e4945d90bd6785226b535f8b248"
+      (get (:headers response) "Content-Length") => nil?
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (:body response) => nil?))
+
+  (facts :requests :thumbnail-integration :original
+    (let [response (client/get (format "http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "6f13d7df6b332e4945d90bd6785226b535f8b248"
+      (get (:headers response) "Content-Disposition") => "inline; filename=\"beach.jpg\""
+      (get (:headers response) "Content-Length") => "189612"
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (digest/sha1 (:body response)) => "a8969142a23801ee3b2d28896f41e9339e1294e6")
+
+    (let [response (client/head (format "http://localhost:8080/bucket/a/ab/beach.jpg/revision/latest" default-port) {:as :byte-array})]
+      (:status response) => 200
+      (get (:headers response) "Surrogate-Key") => "6f13d7df6b332e4945d90bd6785226b535f8b248"
+      (get (:headers response) "Content-Disposition") => "inline; filename=\"beach.jpg\""
+      (get (:headers response) "Content-Length") => nil?
+      (get (:headers response) "Connection") => "close"
+      (get (:headers response) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
+      (:body response) => nil?)))

--- a/test/vignette/storage/core_test.clj
+++ b/test/vignette/storage/core_test.clj
@@ -72,11 +72,14 @@
     (let [local (create-local-storage-system local-path)
           image-store (create-image-storage local)
           resource (create-stored-object (io/file "image-samples/ropes.jpg"))]
-      (save-original image-store resource sample-media-hash) => truthy))
+      (save-original image-store resource sample-media-hash) => truthy
+      (original-exists? image-store sample-media-hash) => true
+      (original-exists? image-store {:image-type "images"}) => false))
 
   (facts :get-original :integration
     (let [local (create-local-storage-system local-path)
           image-store (create-image-storage local)
           resource (create-stored-object (io/file "image-samples/ropes.jpg"))]
       (save-original image-store resource sample-media-hash) => truthy
+      (original-exists? image-store sample-media-hash) => true
       (get-original image-store sample-media-hash) => truthy)))

--- a/test/vignette/storage/local_test.clj
+++ b/test/vignette/storage/local_test.clj
@@ -22,27 +22,33 @@
   (facts :put-object
     (let [local (ls/create-local-storage-system "/tmp/vignette-local-storage")]
       local => truthy
+      (object-exists? local "bucket" "bar") => false
       (put-object local
                   (ls/create-stored-object (io/file "project.clj"))
                   "bucket"
-                  "bar") => truthy))
+                  "bar") => truthy
+      (object-exists? local "bucket" "bar") => true))
 
   (facts :get-object
     (let [local (ls/create-local-storage-system "/tmp/vignette-local-storage")]
       local => truthy
       (get-object local "bucket" "bar") => falsey
+      (object-exists? local "bucket" "bar") => false
       (put-object local
                   (ls/create-stored-object (io/file "project.clj"))
                   "bucket"
                   "bar") => truthy
-      (get-object local "bucket" "bar") => truthy))
+      (get-object local "bucket" "bar") => truthy
+      (object-exists? local "bucket" "bar") => true))
 
   (facts :delete-object
     (let [local (ls/create-local-storage-system "/tmp/vignette-local-storage")]
       local => truthy
       (delete-object local "bucket" "bar") => falsey
+      (object-exists? local "bucket" "bar") => false
       (put-object local
                   (ls/create-stored-object (io/file "project.clj"))
                   "bucket"
                   "bar") => truthy
+      (object-exists? local "bucket" "bar") => true
       (delete-object local "bucket" "bar") => truthy)))

--- a/test/vignette/storage/s3_test.clj
+++ b/test/vignette/storage/s3_test.clj
@@ -48,3 +48,14 @@
     (file-stream ..resource..) => ..file..
     (content-type ..resource..) => ..content-type..
     (s3/put-object ..timeout-creds.. "bucket" "a/ab/image.jpg" ..file.. {:content-type ..content-type..}) => nil))
+
+(facts :s3 :object-exists
+  (object-exists? (create-s3-storage-system ..creds..) ..bucket.. ..path..) => true
+  (provided
+    (add-timeouts :head ..creds..) => ..timeout-creds..
+    (s3/object-exists? ..timeout-creds.. ..bucket.. ..path..) => true)
+
+  (object-exists? (create-s3-storage-system ..creds..) ..bucket.. ..path..) => false
+  (provided
+    (add-timeouts :head ..creds..) => ..timeout-creds..
+    (s3/object-exists? ..timeout-creds.. ..bucket.. ..path..) => false))


### PR DESCRIPTION
This PR adds `HEAD` support to vignette routes to satisfy the vignette side the new purger integration. This turned out to be a little more complicated than expected and the behavior depends upon the order of the route definition. Specifically `HEAD` needs to be defined before `GET` because of [this block in compojure](https://github.com/weavejester/compojure/blob/639fffd3f8b77153644d0c9b87bca5af56be0cb0/src/compojure/core.clj#L28).

One way to handle `HEAD` is to set the `:body` to `nil` in a `GET` request. It looks like this is a shortcut that is imposed by compojure. This is probably fine in the case of materialized bodies but could be problematic when working with file streams as we are.

This might be an pre-mature optimization but in our case, we probably want to make sure that we don't open any more connections than necessary. To this end, the `HEAD` support provided here is pragmatic in that it only tests to see if the object exists in CEPH. It also means that the response does not include the `Content-Type` or the `Content-Length`. Omitting the latter is probably expected, but probably not the former.

Also of note is that the `Surrogate-Key` header will now be supplied when the resource is not found (e.g. 404). This is because in practice, by the time we do the purge from the new purger the object will like have already been deleted in CEPH. If we omit the `Surrogate-Key` on 404 then we can't complete the purge.

Also note that legacy HEAD support is still only partially supported. The request will probably hang because the `Content-Length` will still be there because of the above noted issue with compojure.

https://wikia-inc.atlassian.net/browse/PLATFORM-826
https://wikia-inc.atlassian.net/browse/PLATFORM-888

/cc @nmonterroso @owend @ljagiello 

Todo:
  * [x] Update the documentation regarding HEAD