### PR TITLE
replace multiple slashes in :uri with a single slash

### DIFF
--- a/src/vignette/http/middleware.clj
+++ b/src/vignette/http/middleware.clj
@@ -1,6 +1,7 @@
 (ns vignette.http.middleware
   (:require [environ.core :refer [env]]
             [compojure.response :refer [render]]
+            [clojure.string :as string]
             [ring.util.response :refer [response status charset header get-header]]
             [slingshot.slingshot :refer [try+ throw+]]
             [vignette.util.image-response :refer :all]
@@ -67,6 +68,11 @@
 
       :else (header response cache-control-header (format "public, max-age=%d"
                                                     (/ (hours-to-seconds 1) 2))))))
+
+(defn multiple-slash->single-slash [handler]
+  (fn [request]
+    (let [uri (string/replace (:uri request) #"(\/{2,})" "/")]
+      (handler (assoc request :uri uri)))))
 
 (defn hours-to-seconds
   [hours]

--- a/src/vignette/http/middleware.clj
+++ b/src/vignette/http/middleware.clj
@@ -68,10 +68,12 @@
 
       :else (header response cache-control-header (format "public, max-age=%d"
                                                     (/ (hours-to-seconds 1) 2))))))
+(defn uri-multiple-slash-replacement [uri]
+  (string/replace uri #"(\/{2,})" "/"))
 
 (defn multiple-slash->single-slash [handler]
   (fn [request]
-    (let [uri (string/replace (:uri request) #"(\/{2,})" "/")]
+    (let [uri (uri-multiple-slash-replacement (:uri request))]
       (handler (assoc request :uri uri)))))
 
 (defn hours-to-seconds

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -112,5 +112,6 @@
                        (bad-request-path))))
       (wrap-params)
       (exception-catcher)
+      (multiple-slash->single-slash)
       (request-timer)
       (add-headers)))

--- a/test/vignette/http/middleware_test.clj
+++ b/test/vignette/http/middleware_test.clj
@@ -11,3 +11,8 @@
   (get (:headers (add-cache-control-header {:status 404})) "Cache-Control") => "public, max-age=3600"
   (get (:headers (add-cache-control-header {:status 200})) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
   (get (:headers (add-cache-control-header {:status 201})) "Cache-Control") => "public, s-maxage=31536000, max-age=86400")
+
+(facts :multiple-slash->single-slash
+       (uri-multiple-slash-replacement "/a/b/c/d") => "/a/b/c/d"
+       (uri-multiple-slash-replacement "/a//b/c/d") => "/a/b/c/d"
+       (uri-multiple-slash-replacement "//a///b////c/////d") => "/a/b/c/d")


### PR DESCRIPTION
@drsnyder 
https://wikia-inc.atlassian.net/browse/PLATFORM-896

Adds middleware to replace multiple slashes with a single slash. These account for ~5% of our `bad-request-path` errors.