### PR TITLE
commas in quotes in content-disposition header

### DIFF
--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -1,5 +1,6 @@
 (ns vignette.util.image-response
   (:require [clojure.java.io :refer [file]]
+            [clojure.string :as string]
             [compojure.route :refer [not-found]]
             [ring.util.response :refer [response status header]]
             [digest :as digest]
@@ -58,7 +59,7 @@
   [response-map image-map]
   (if (original image-map)
     (let [requested-format (query-opt image-map :format)
-          filename (cond-> (original image-map)
+          filename (cond-> (string/replace (original image-map) "\"" "\\\"")
                      requested-format (str "." requested-format))]
       (header response-map "Content-Disposition" (format "inline; filename=\"%s\"" filename)))
     response-map))

--- a/test/vignette/util/image_response_test.clj
+++ b/test/vignette/util/image_response_test.clj
@@ -20,3 +20,8 @@
         response-headers (:headers response)]
     (get response-headers "Surrogate-Key") => "7d1d24f2c2af364882953e8c97bf90092c2f7a08"
     (get response-headers "Content-Disposition") => "inline; filename=\"ropes.jpg\""))
+
+(facts :add-content-disposition-header
+       (add-content-disposition-header {} {:original "some-file.png"}) => {:headers {"Content-Disposition" "inline; filename=\"some-file.png\""}}
+       (add-content-disposition-header {} {:original "some-\"file\".png"}) => {:headers {"Content-Disposition" "inline; filename=\"some-\\\"file\\\".png\""}}
+       (add-content-disposition-header {} {:original "some-\"file,_with_comma!\".png"}) => {:headers {"Content-Disposition" "inline; filename=\"some-\\\"file,_with_comma!\\\".png\""}})


### PR DESCRIPTION
@drsnyder 
https://wikia-inc.atlassian.net/browse/PLATFORM-1053

Looks like a `Content-Disposition` header with quotes containing a comma (ex: `Content-Disposition: inline; filename="some_filename\"with,stuff\""`) cause a duplicate header problem in Chrome. Trick seems to be to return a literal `\"` back, which means escaping the quote to be `\\\"` :/