### PR TITLE
call force-thumb? for Vignette-style urls

### DIFF
--- a/src/vignette/http/legacy/route_helpers.clj
+++ b/src/vignette/http/legacy/route_helpers.clj
@@ -1,10 +1,8 @@
 (ns vignette.http.legacy.route-helpers
   (:require [useful.experimental :refer [cond-let]]
-            [vignette.util.external-hotlinking :refer :all]
             [vignette.protocols :refer :all]
             [vignette.storage.protocols :refer :all]
-            [vignette.media-types :refer [archive-dir]]
-            [vignette.util.thumbnail :as u])
+            [vignette.media-types :refer [archive-dir]])
   (:import [java.net URLDecoder]))
 
 (def default-width 200)
@@ -18,8 +16,7 @@
          route->original-map
          route->interactive-maps-map
          route->interactive-maps-thumbnail-map
-         route->timeline-map
-         original-request->file)
+         route->timeline-map)
 
 (defn archive? [map]
   (= (:zone map) (str "/" archive-dir)))
@@ -142,9 +139,3 @@
                  :window-width (str window-width)
                  :window-height (str window-height)))
     map))
-
-(defn original-request->file
-  [request system image-params]
-  (if (force-thumb? request)
-    (u/get-or-generate-thumbnail system (image-params->forced-thumb-params image-params))
-    (get-original (store system) image-params)))

--- a/src/vignette/http/legacy/routes.clj
+++ b/src/vignette/http/legacy/routes.clj
@@ -4,6 +4,7 @@
             [vignette.http.legacy.route-helpers :refer :all]
             [vignette.protocols :refer :all]
             [vignette.storage.protocols :refer :all]
+            [vignette.util.external-hotlinking :refer [original-request->file]]
             [vignette.util.regex :refer :all]
             [vignette.util.image-response :refer :all]
             [vignette.util.thumbnail :as u]))

--- a/src/vignette/http/route_helpers.clj
+++ b/src/vignette/http/route_helpers.clj
@@ -1,5 +1,6 @@
 (ns vignette.http.route-helpers
-  (:require [vignette.util.image-response :refer :all]
+  (:require [vignette.util.external-hotlinking :refer [original-request->file]]
+            [vignette.util.image-response :refer :all]
             [vignette.util.query-options :refer :all]
             [vignette.protocols :refer :all]
             [vignette.storage.core :refer :all]
@@ -8,14 +9,14 @@
 
 
 (defn handle-thumbnail
-  [system image-params]
+  [system image-params request]
   (if-let [thumb (u/get-or-generate-thumbnail system image-params)]
     (create-image-response thumb image-params)
     (error-response 404 image-params)))
 
 (defn handle-original
-  [system image-params]
-  (if-let [file (get-original (store system) image-params)]
+  [system image-params request]
+  (if-let [file (original-request->file request system image-params)]
     (create-image-response file image-params)
     (error-response 404 image-params)))
 

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -90,7 +90,8 @@
         request
         (get-handler system
                      (route->map-fn (:route-params request)
-                                    request)))])
+                                    request)
+                     request))])
 
 (defn app-routes
   [system]

--- a/src/vignette/util/external_hotlinking.clj
+++ b/src/vignette/util/external_hotlinking.clj
@@ -1,4 +1,7 @@
-(ns vignette.util.external-hotlinking)
+(ns vignette.util.external-hotlinking
+  (:require [vignette.protocols :refer :all]
+            [vignette.storage.protocols :refer :all]
+            [vignette.util.thumbnail :as u]))
 
 (def force-header-name "x-vignette-force-thumb")
 (def force-header-val "1")
@@ -13,3 +16,9 @@
 
 (defn image-params->forced-thumb-params [image-params]
   (merge image-params force-thumb-params))
+
+(defn original-request->file
+  [request system image-params]
+  (if (force-thumb? request)
+    (u/get-or-generate-thumbnail system (image-params->forced-thumb-params image-params))
+    (get-original (store system) image-params)))

--- a/test/vignette/http/route_helpers_test.clj
+++ b/test/vignette/http/route_helpers_test.clj
@@ -11,24 +11,24 @@
   (:import java.io.FileNotFoundException))
 
 (facts :handle-thumbnail
-  (handle-thumbnail ..system.. ..params..) => ..response..
+  (handle-thumbnail ..system.. ..params.. ..request..) => ..response..
   (provided
     (u/get-or-generate-thumbnail ..system.. ..params..) => ..thumb..
     (create-image-response ..thumb.. ..params..) => ..response..)
 
-  (handle-thumbnail ..system.. ..params..) => ..error..
+  (handle-thumbnail ..system.. ..params.. ..request..) => ..error..
   (provided
     (u/get-or-generate-thumbnail ..system.. ..params..) => nil
     (error-response 404 ..params..) => ..error..))
 
 (facts :handle-original
-  (handle-original ..system.. ..params..) => ..response..
+  (handle-original ..system.. ..params.. ..request..) => ..response..
   (provided
     (store ..system..) => ..store..
     (sp/get-original ..store.. ..params..) => ..original..
     (create-image-response ..original.. ..params..) => ..response..)
 
-  (handle-original ..system.. ..params..) => ..error..
+  (handle-original ..system.. ..params.. ..request..) => ..error..
   (provided
     (store ..system..) => ..store..
     (sp/get-original ..store.. ..params..) => nil


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-1121
@drsnyder 

Looks like the functionality to force a thumbnail is only happening for legacy URLs. I also made sure the `X-Vignette-Force-Thumb` header is being properly created by Varnish.