### PR TITLE
PLATFORM-966: cache images for 14 days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 /tmp
 *.iml
 /logs
+*.swp

--- a/src/vignette/http/middleware.clj
+++ b/src/vignette/http/middleware.clj
@@ -58,9 +58,8 @@
   (let [status (get response :status 0)]
     (cond
       (and (>= status 200) (< status 300))
-      (header response cache-control-header (format "public, s-maxage=%d, max-age=%d",
-                                                    (hours-to-seconds (* 24 365))
-                                                    (hours-to-seconds 24)))
+      (header response cache-control-header (format "public, max-age=%d",
+                                                    (hours-to-seconds (* 14 24))))
 
       (and (>= status 400) (< status 500))
       (header response cache-control-header (format "public, max-age=%d"

--- a/src/vignette/http/middleware.clj
+++ b/src/vignette/http/middleware.clj
@@ -59,7 +59,7 @@
     (cond
       (and (>= status 200) (< status 300))
       (header response cache-control-header (format "public, max-age=%d",
-                                                    (hours-to-seconds (* 14 24))))
+                                                    (hours-to-seconds (* 365 24))))
 
       (and (>= status 400) (< status 500))
       (header response cache-control-header (format "public, max-age=%d"

--- a/test/vignette/http/middleware_test.clj
+++ b/test/vignette/http/middleware_test.clj
@@ -9,8 +9,8 @@
   (get (:headers (add-cache-control-header {:status 400})) "Cache-Control") => "public, max-age=3600"
   (get (:headers (add-cache-control-header {:status 401})) "Cache-Control") => "public, max-age=3600"
   (get (:headers (add-cache-control-header {:status 404})) "Cache-Control") => "public, max-age=3600"
-  (get (:headers (add-cache-control-header {:status 200})) "Cache-Control") => "public, s-maxage=31536000, max-age=86400"
-  (get (:headers (add-cache-control-header {:status 201})) "Cache-Control") => "public, s-maxage=31536000, max-age=86400")
+  (get (:headers (add-cache-control-header {:status 200})) "Cache-Control") => "public, max-age=1209600"
+  (get (:headers (add-cache-control-header {:status 201})) "Cache-Control") => "public, max-age=1209600")
 
 (facts :multiple-slash->single-slash
        (uri-multiple-slash-replacement "/a/b/c/d") => "/a/b/c/d"

--- a/test/vignette/http/middleware_test.clj
+++ b/test/vignette/http/middleware_test.clj
@@ -9,8 +9,8 @@
   (get (:headers (add-cache-control-header {:status 400})) "Cache-Control") => "public, max-age=3600"
   (get (:headers (add-cache-control-header {:status 401})) "Cache-Control") => "public, max-age=3600"
   (get (:headers (add-cache-control-header {:status 404})) "Cache-Control") => "public, max-age=3600"
-  (get (:headers (add-cache-control-header {:status 200})) "Cache-Control") => "public, max-age=1209600"
-  (get (:headers (add-cache-control-header {:status 201})) "Cache-Control") => "public, max-age=1209600")
+  (get (:headers (add-cache-control-header {:status 200})) "Cache-Control") => "public, max-age=31536000"
+  (get (:headers (add-cache-control-header {:status 201})) "Cache-Control") => "public, max-age=31536000")
 
 (facts :multiple-slash->single-slash
        (uri-multiple-slash-replacement "/a/b/c/d") => "/a/b/c/d"


### PR DESCRIPTION
Read the full story in https://wikia-inc.atlassian.net/browse/PLATFORM-966

Cache images for 14 days on both CDN and client level

With `s-maxage` being set to a value higher than `max-age` we were
getting lots of requests from clients trying to revalidate the image
because `Age` header (returned by CDN) was higher than `max-age` sent to
the client.

14 days will cover ~75% of images:

```
Age 5th percentile - 1.10 days
Age 10th percentile - 1.85 days
Age 25th percentile - 3.86 days
Age 50th percentile - 9.94 days
Age 75th percentile - 15.57 days
Age 90th percentile - 31.94 days
Age 95th percentile - 48.79 days
Age 99th percentile - 50.78 days
```

@nmonterroso / @drsnyder / @ljagiello 