### PR TITLE
Add a toggle for caching thumbnails in vignette

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ Below is a list of environment variables that will affect the vignette runtime.
  * `CONVERT_CONSTRAINTS`          universal options to pass to ImageMagick. see bin/thumbnail
  * `UNSUPPORTED_REDIRECT_HOST`    on an unsupported legacy thumbnail request, host to redirect
 
+## Command Line Options
+
+To see the command line options available execute `lein run -- -h`. The notable
+command line options are the following:
+
+ * -C,--cache-thumbnails: enable thumbnail caching. When this option is provided
+   thumbnails will be written to and read from the backing storage provided. The
+   default is false.
+ * -m,mode <MODE>:        the storage mode. Options are s3 or local. See above
+   for the environment variables toggling these settings. The default is s3.
+ * -p,port <PORT>:        the port the HTTP server will listen on. The default
+   is 8080.
+
 ## Testing
 
 All testing is done using [Midje](https://github.com/marick/Midje). Running `lein midje` will run all of the tests.

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.cli "0.3.1"]
                  [cheshire "5.3.1"]
-                 [clj-aws-s3 "0.3.10"]
+                 [clj-aws-s3 "0.3.10" :exclusions [joda-time]]
                  [clout "2.1.0"]
                  [compojure "1.3.2"]
                  [com.novemberain/pantomime "2.3.0"]

--- a/src/vignette/core.clj
+++ b/src/vignette/core.clj
@@ -12,7 +12,7 @@
   (:gen-class))
 
 (def cli-specs [["-h" "--help" "Show help"]
-                ["-C" "--cache-thumbnails" "Turns thumbnail caching on"]
+                ["-C" "--cache-thumbnails" "Enable thumbnail caching"]
                 ["-m" "--mode running mode" "Object storage to use (s3 or local)"
                  :default "local"
                  :validate [#(contains? #{"local" "s3"} %) "Supported modes are \"local\" and \"s3\""]]

--- a/src/vignette/core.clj
+++ b/src/vignette/core.clj
@@ -12,6 +12,7 @@
   (:gen-class))
 
 (def cli-specs [["-h" "--help" "Show help"]
+                ["-C" "--cache-thumbnails" "Turns thumbnail caching on"]
                 ["-m" "--mode running mode" "Object storage to use (s3 or local)"
                  :default "local"
                  :validate [#(contains? #{"local" "s3"} %) "Supported modes are \"local\" and \"s3\""]]
@@ -38,7 +39,7 @@
                              (i/create-integration-env)
                              (create-local-storage-system i/integration-path))
                            (create-s3-storage-system storage-creds))
-          image-store (create-image-storage object-storage)
+          image-store (create-image-storage object-storage (:cache-thumbnails opts))
           system (create-system image-store)]
       (println (format "Mode: %s. Starting server on %d..." (:mode opts) (:port opts)))
       (start system (:port opts)))))

--- a/src/vignette/core.clj
+++ b/src/vignette/core.clj
@@ -12,7 +12,8 @@
   (:gen-class))
 
 (def cli-specs [["-h" "--help" "Show help"]
-                ["-C" "--cache-thumbnails" "Enable thumbnail caching"]
+                ["-C" "--cache-thumbnails" "Enable thumbnail caching"
+                 :default false]
                 ["-m" "--mode running mode" "Object storage to use (s3 or local)"
                  :default "local"
                  :validate [#(contains? #{"local" "s3"} %) "Supported modes are \"local\" and \"s3\""]]

--- a/src/vignette/storage/core.clj
+++ b/src/vignette/storage/core.clj
@@ -26,19 +26,21 @@
                   (mt/wikia object-map)
                   (get-path object-map)))
 
-(defrecord ImageStorage [store]
+(defrecord ImageStorage [store cache-thumbnails]
   ImageStorageProtocol
 
   (save-thumbnail [this resource thumb-map]
-    (put* (:store this)
-          resource
-          thumb-map
-          mt/thumbnail-path))
+    (when (:cache-thumbnails this)
+      (put* (:store this)
+            resource
+            thumb-map
+            mt/thumbnail-path)))
 
   (get-thumbnail [this thumb-map]
-    (get* (:store this)
-          thumb-map
-          mt/thumbnail-path))
+    (when (:cache-thumbnails this)
+      (get* (:store this)
+            thumb-map
+            mt/thumbnail-path)))
 
   (save-original [this resource original-map]
     (put* (:store this)
@@ -57,5 +59,7 @@
              mt/original-path)))
 
 (defn create-image-storage
-  [store]
-  (->ImageStorage store))
+  ([store cache-thumbnails]
+   (->ImageStorage store cache-thumbnails))
+  ([store]
+   (create-image-storage store true)))

--- a/test/vignette/storage/core_test.clj
+++ b/test/vignette/storage/core_test.clj
@@ -59,6 +59,14 @@
       image-store => truthy
       (save-thumbnail image-store resource sample-thumbnail-hash) => truthy))
 
+  (facts :save-thumbnail :not :cache-thumbnails
+    (let [local (create-local-storage-system local-path)
+          image-store (create-image-storage local false)
+          resource (create-stored-object (io/file "image-samples/ropes.jpg"))]
+      local => truthy
+      image-store => truthy
+      (save-thumbnail image-store resource sample-thumbnail-hash) => falsey))
+
   (facts :get-thumbnail :integration
     (let [local (create-local-storage-system local-path)
           image-store (create-image-storage local)
@@ -66,6 +74,14 @@
       (get-thumbnail image-store sample-thumbnail-hash) => falsey
       (save-thumbnail image-store resource sample-thumbnail-hash) => truthy
       (get-thumbnail image-store sample-thumbnail-hash) => truthy))
+
+  (facts :get-thumbnail :not :cache-thumbnails
+    (let [local (create-local-storage-system local-path)
+          image-store (create-image-storage local false)
+          resource (create-stored-object (io/file "image-samples/ropes.jpg"))]
+      (get-thumbnail image-store sample-thumbnail-hash) => falsey
+      (save-thumbnail image-store resource sample-thumbnail-hash) => falsey
+      (get-thumbnail image-store sample-thumbnail-hash) => falsey))
 
 
   (facts :save-original :integration


### PR DESCRIPTION
Added `:cache-thumbnails` to storage core and the command line interface. When this toggle is true, thumbnails will not be read from nor written to the backing storage. They will always be generated at request time.

https://wikia-inc.atlassian.net/browse/SERVICES-367

/cc @nmonterroso @ljagiello 
