### PR TITLE
Second attempt at fixing Routing concatenation

### DIFF
--- a/src/vignette/setup.clj
+++ b/src/vignette/setup.clj
@@ -23,7 +23,8 @@
    })
 
 (defn image-routes [stores]
-  (list
-    (def-api-context wiki-context (:wikia-store stores))
-    (def-api-context uuid-context (:static-store stores))
+  (concat
+    (list
+      (def-api-context wiki-context (:wikia-store stores))
+      (def-api-context uuid-context (:static-store stores)))
     (hlr/legacy-routes (:wikia-store stores))))

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -14,16 +14,10 @@
             [vignette.http.proto-routes :as proto]
             [vignette.test.helper :refer [context-route-matches]]
             [vignette.util.thumbnail :as u]
+            [vignette.setup :refer [image-routes]]
             [vignette.http.legacy.routes :as hlr]))
 
 (def in-wiki-context-route-matches (partial context-route-matches vignette.http.api-routes/wiki-context))
-
-(defn image-routes [stores]
-  (concat
-  (list
-    (def-api-context wiki-context (:wikia-store stores))
-    (def-api-context uuid-context (:static-store stores)))
-  (hlr/legacy-routes (:wikia-store stores))))
 
 (facts :original-route
        (route-matches proto/original-route (request :get "/swift/v1")) => falsey


### PR DESCRIPTION
```hlr/legacy-routes``` return list of routes which in turn caused all following routes to be overriden.
This change fixes concatenation of routes list so instead of list like:
```[ route_a route_b [sub_a sub _b] ]```
We get ```[route_a route_b sub_a sub_b]```

Previous change was doing the same but it only fixed tests :disappointed:. Here I also make tests use vignette.setup as a source of sample routing configuration which aligns it with how production is configured.
@macbre @michalroszka 