### PR TITLE
PLATFORM-1541 Add original filename suffix to temporary file && fix Mime detection

### DIFF
--- a/src/vignette/util/filesystem.clj
+++ b/src/vignette/util/filesystem.clj
@@ -17,7 +17,7 @@
                      (str "." suffix))
          uuid (if (not (empty? prefix))
                 (str prefix "_" (UUID/randomUUID) extension)
-                (UUID/randomUUID))
+                (str (UUID/randomUUID) extension))
          filename (resolve-local-path temp-file-location uuid)]
      (create-local-path (get-parent filename))
      filename))

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -112,7 +112,7 @@
 (defn original->local
   "Take the original and make it local."
   [original]
-  (let [temp-file (io/file (temp-filename))]
+  (let [temp-file (io/file (temp-filename nil (filename original)))]
     (when (transfer! original temp-file)
       temp-file)))
 

--- a/test/vignette/storage/s3_test.clj
+++ b/test/vignette/storage/s3_test.clj
@@ -17,9 +17,10 @@
     (add-timeouts :get ..creds..) => ..timeout-creds..
     (safe-get-object ..timeout-creds.. "bucket" "a/ab/image.jpg") => {:content ..stream..
                                                                       :metadata {:content-length ..length..
-                                                                                 :content-type ..content-type..}}
+                                                                                 :content-type ..content-type..}
+                                                                      :key "a/ab/image.jpg"}
     (create-stored-object ..stream.. {:content-length ..length..
-                                          :content-type ..content-type..}) => ..object..)
+                                          :content-type ..content-type..} "image.jpg") => ..object..)
 
   (get-object (create-s3-storage-system ..creds..) "bucket" "a/ab/image.jpg") => falsey
   (provided


### PR DESCRIPTION
Without proper filename suffix both Tika/Pantomime and Imagick mime detection failed to work properly especially for SVG images.

This change reintroduces filename suffix in temp file and allows for both detection to correctly handle SVG files.