### PR TITLE
PLATFORM-1644 PLATFORM-1265 Fix thumbnails for videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,13 @@ and `c,d` are the same but for `y`. In Vignette URLs, we specify the `x-offset`,
 which is the same as a above, but we specify window-width instead of `x-endpoint`
 (where `window-width` is `x-endpoint - x-offset`).
 
+### Media Passthrough for not certain mime-types
+
+When encountered media types:
+ - audio/ogg
+ - video/ogg
+data will be passed through as - is without applying any thumbnailing operations.
+
 ## Other HTTP Methods Supported
 
 ### HEAD

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -111,7 +111,7 @@
             "unable to get original for thumbnailing")))
 
 (defn- extract-extension [filename]
-  (last (split filename #"\.")))
+  (last (rest (split filename #"\."))))
 
 (defn original->local
   "Take the original and make it local."

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -24,25 +24,18 @@
                                                   "/usr/local/bin/thumbnail"
                                                   "bin/thumbnail")))
 
-(def options-map {:height "height"
-                  :width "width"
+(def options-map {:height         "height"
+                  :width          "width"
                   :thumbnail-mode "mode"
-                  :x-offset "x-offset"
-                  :y-offset "y-offset"
-                  :window-width "window-width"
-                  :window-height "window-height"})
+                  :x-offset       "x-offset"
+                  :y-offset       "y-offset"
+                  :window-width   "window-width"
+                  :window-height  "window-height"})
 
-(def unsupported-mime-types #{"audio/ogg"
-                              "video/ogg"})
-
-(defn assert-original-mime-type
-  [file thumb-map]
-  (let [mime-type (mime-type-of file)]
-    (when (contains? unsupported-mime-types mime-type)
-      (throw+ {:type :convert-error
-               :response-code 404
-               :content-type mime-type
-               :thumb-map thumb-map} "unsupported content type"))))
+(def passthrough-mime-types #{"audio/ogg" "video/ogg"})
+(defn is-passthrough-required
+  [file]
+  (contains? passthrough-mime-types (mime-type-of file)))
 
 (defn route-map->thumb-args
   [thumb-map]
@@ -59,7 +52,6 @@
 
 (defn original->thumbnail
   [resource thumb-map]
-  (assert-original-mime-type resource thumb-map)
   (let [temp-file (temp-filename (str (wikia thumb-map) "_thumb"))
         base-command [thumbnail-bin
                       "--in" (.getAbsolutePath resource)
@@ -73,8 +65,8 @@
       (or (zero? (:exit sh-out))
           (and (= 1 (:exit sh-out))
                (file-exists? temp-file))) (io/file temp-file)
-      :else (throw+ {:type :convert-error
-                     :error-code (:exit sh-out)
+      :else (throw+ {:type         :convert-error
+                     :error-code   (:exit sh-out)
                      :error-string (:err sh-out)}
                     "thumbnailing error"))))
 
@@ -83,7 +75,7 @@
   (if-let [thumb (and (not (q/query-opt thumb-map :replace))
                       (get-thumbnail store thumb-map))]
     (do
-      (perf/publish  {:thumbnail-cache-hit 1})
+      (perf/publish {:thumbnail-cache-hit 1})
       thumb)
     (when-let [thumb (generate-thumbnail store thumb-map)]
       thumb)))
@@ -94,19 +86,21 @@
   The original will be removed after the thumbnailing is completed."
   [store thumb-map]
   (if-let [original (get-original store thumb-map)]
-    (when-let [local-original (original->local original)]
-      (try+
-        (when-let [thumb (original->thumbnail local-original thumb-map)]
-          (perf/publish  {:generate-thumbail 1})
-          (ls/create-stored-object thumb (fn [stored-object]
-                                           (background-save-thumbnail store
-                                                                      stored-object
-                                                                      thumb-map))))
-        (catch Object _ (throw+))
-        (finally
-          (background-delete-file local-original))))
-    (throw+ {:type :convert-error
-             :thumb-map thumb-map
+    (if (is-passthrough-required original)
+      original
+      (when-let [local-original (original->local original)]
+        (try+
+          (when-let [thumb (original->thumbnail local-original thumb-map)]
+            (perf/publish {:generate-thumbail 1})
+            (ls/create-stored-object thumb (fn [stored-object]
+                                             (background-save-thumbnail store
+                                                                        stored-object
+                                                                        thumb-map))))
+          (catch Object _ (throw+))
+          (finally
+            (background-delete-file local-original)))))
+    (throw+ {:type          :convert-error
+             :thumb-map     thumb-map
              :response-code 404}
             "unable to get original for thumbnailing")))
 

--- a/test/vignette/util/thumbnail_test.clj
+++ b/test/vignette/util/thumbnail_test.clj
@@ -25,7 +25,6 @@
        ; successful run
        (original->thumbnail beach-file beach-map) => truthy
        (provided
-         (mime-type-of beach-file) => "image/jpg"
          (run-thumbnailer anything) => {:exit 0})
 
        ; failed run
@@ -33,9 +32,10 @@
        (provided
          (run-thumbnailer anything) => {:exit 1 :err 256 :out "testing failure"})
 
-       ;invalid mime type
-       (original->thumbnail ..file.. beach-map) => (throws Exception)
+       ;special mime type
+       (generate-thumbnail ..store.. beach-map) => ..file..
        (provided
+         (get-original ..store.. beach-map) => ..file..
          (mime-type-of ..file..) => "video/ogg"))
 
 (facts :orignal->local-maintains-file-extension
@@ -51,6 +51,7 @@
        (provided
          (get-original ..store.. beach-map) => ..original..
          (original->local ..original..) => ..local..
+         (is-passthrough-required ..original..) => false
          (original->thumbnail ..local.. beach-map) => ..thumb..
          (background-delete-file ..local..) => true
          (create-stored-object ..thumb.. & anything) => ..object..)
@@ -63,6 +64,7 @@
        (provided
          (get-original ..store.. beach-map) => ..original..
          (original->local ..original..) => ..local..
+         (is-passthrough-required ..original..) => false
          (background-delete-file ..local..) => true
          (original->thumbnail ..local.. beach-map) => nil))
 
@@ -95,7 +97,7 @@
        (route-map->thumb-args beach-map) => (contains ["--height" "100" "--width" "100"
                                                        "--mode" "thumbnail"] :in-any-order))
 
-(facts :assert-original-mime-type
-       (assert-original-mime-type "" {}) => nil
-       (assert-original-mime-type "file.jpg" {}) => nil
-       (assert-original-mime-type "file.ogv" {}) => (throws ExceptionInfo))
+(facts :passthrough-mime-types
+       (is-passthrough-required "") => false
+       (is-passthrough-required "file.jpg") => false
+       (is-passthrough-required "file.ogv") => true)

--- a/test/vignette/util/thumbnail_test.clj
+++ b/test/vignette/util/thumbnail_test.clj
@@ -10,14 +10,14 @@
             [vignette.storage.local :as ls])
   (:import [clojure.lang ExceptionInfo]))
 
-(def beach-map {:request-type :thumbnail
-                :original "beach.jpg"
-                :middle-dir "3"
-                :top-dir "35"
-                :wikia "lotr"
+(def beach-map {:request-type   :thumbnail
+                :original       "beach.jpg"
+                :middle-dir     "3"
+                :top-dir        "35"
+                :wikia          "lotr"
                 :thumbnail-mode "thumbnail"
-                :height "100"
-                :width "100"})
+                :height         "100"
+                :width          "100"})
 
 (def beach-file (io/file "image-samples/beach.jpg"))
 
@@ -40,27 +40,31 @@
 
 (facts :orignal->local-maintains-file-extension
        (.getName (original->local
-         (ls/create-stored-object (io/file "project.clj")))) => #".*\.clj$")
+                   (ls/create-stored-object (io/file "project.clj")))) => (just #"[-0-9a-f]{36}\.clj"))
+
+(facts :orignal->local-handles-no-file-extension
+       (.getName (original->local
+                   (ls/create-stored-object (io/file "LICENSE")))) => (just #"[-0-9a-f]{36}"))
 
 (facts :generate-thumbnail
-  (generate-thumbnail ..store.. beach-map) => ..object..
-  (provided
-    (get-original ..store.. beach-map) => ..original..
-    (original->local ..original..) => ..local..
-    (original->thumbnail ..local.. beach-map) => ..thumb..
-    (background-delete-file ..local..) => true
-    (create-stored-object ..thumb.. & anything) => ..object..)
+       (generate-thumbnail ..store.. beach-map) => ..object..
+       (provided
+         (get-original ..store.. beach-map) => ..original..
+         (original->local ..original..) => ..local..
+         (original->thumbnail ..local.. beach-map) => ..thumb..
+         (background-delete-file ..local..) => true
+         (create-stored-object ..thumb.. & anything) => ..object..)
 
-  (generate-thumbnail ..store.. beach-map) => (throws ExceptionInfo)
-  (provided
-    (get-original ..store.. beach-map) => nil)
+       (generate-thumbnail ..store.. beach-map) => (throws ExceptionInfo)
+       (provided
+         (get-original ..store.. beach-map) => nil)
 
-  (generate-thumbnail ..store.. beach-map) => falsey
-  (provided
-    (get-original ..store.. beach-map) => ..original..
-    (original->local ..original..) => ..local..
-    (background-delete-file ..local..) => true
-    (original->thumbnail ..local.. beach-map) => nil)) 
+       (generate-thumbnail ..store.. beach-map) => falsey
+       (provided
+         (get-original ..store.. beach-map) => ..original..
+         (original->local ..original..) => ..local..
+         (background-delete-file ..local..) => true
+         (original->thumbnail ..local.. beach-map) => nil))
 
 (facts :get-or-generate-thumbnail
        ; get existing
@@ -89,9 +93,9 @@
 
 (facts :route-map->thumb-args
        (route-map->thumb-args beach-map) => (contains ["--height" "100" "--width" "100"
-                                                      "--mode" "thumbnail"] :in-any-order))
+                                                       "--mode" "thumbnail"] :in-any-order))
 
 (facts :assert-original-mime-type
-  (assert-original-mime-type "" {}) => nil
-  (assert-original-mime-type "file.jpg" {}) => nil
-  (assert-original-mime-type "file.ogv" {}) => (throws ExceptionInfo))
+       (assert-original-mime-type "" {}) => nil
+       (assert-original-mime-type "file.jpg" {}) => nil
+       (assert-original-mime-type "file.ogv" {}) => (throws ExceptionInfo))


### PR DESCRIPTION
After #101 some files without extension failed to thumbnail properly

Additionally I included fix for PLATFORM-1265 by just copying the original if specified mime has been encountered.

I believe that if vignette is not able to crop certain files then it should at pass them unmodified. As 'best' effort' to serve the content.

