### PR TITLE
PLATFORM-1643 Allow handling of avatars without any name in metadata

### DIFF
--- a/src/vignette/storage/static_assets.clj
+++ b/src/vignette/storage/static_assets.clj
@@ -7,7 +7,7 @@
 (defn- parse-content-disp
   [header]
   (when-let [m (if header (re-find #"(?i)filename=\"(.*)\"" header))]
-    (second m)))
+    (or (second m) "")))
 
 (defrecord AsyncResponseStoredObject [response] StoredObjectProtocol
   (file-stream [this] (-> this :response :body))

--- a/src/vignette/util/consul.clj
+++ b/src/vignette/util/consul.clj
@@ -4,7 +4,7 @@
 
 (def default-consul-hostname "localhost")
 (def default-consul-http-port 8500)
-(def default-service-query-tag "production")
+(def default-service-query-tag "prod")
 
 (def service-query-tag (env :consul-query-tag default-service-query-tag))
 

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -35,7 +35,7 @@
 (def passthrough-mime-types #{"audio/ogg" "video/ogg"})
 (defn is-passthrough-required
   [file]
-  (contains? passthrough-mime-types (mime-type-of file)))
+  (contains? passthrough-mime-types (mime-type-of (or file ""))))
 
 (defn route-map->thumb-args
   [thumb-map]

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -105,7 +105,9 @@
             "unable to get original for thumbnailing")))
 
 (defn- extract-extension [filename]
-  (last (rest (split filename #"\."))))
+  (if filename
+    (last (rest (split filename #"\.")))
+    ""))
 
 (defn original->local
   "Take the original and make it local."

--- a/test/vignette/util/thumbnail_test.clj
+++ b/test/vignette/util/thumbnail_test.clj
@@ -100,6 +100,7 @@
                                                        "--mode" "thumbnail"] :in-any-order))
 
 (facts :passthrough-mime-types
+       (is-passthrough-required nil) => false
        (is-passthrough-required "") => false
        (is-passthrough-required "file.jpg") => false
        (is-passthrough-required "file.ogv") => true)


### PR DESCRIPTION
Some badly uploaded avatars currently have empty file names.
This allows to handle those edge cases.