### PR TITLE
Fix detecting animated GIFs after output format of identify has changed

### DIFF
--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -404,7 +404,7 @@ function animated_thumb_params() {
 
 
 function is_animated() {
-	num=$($IDENTIFY -format "%n" "$1")
+	num=$($IDENTIFY -format "%n\n" "$1"|head -n 1)
 	if [[ $num -gt 1 ]]; then
 		return 1
 	else


### PR DESCRIPTION
`identify` version 6.9.0-4 started to output a separate entry per each animation frame instead of a single value when run using the following command line:
`identify -format %n ....`

The change solves the issue and handles both old and new output correctly.

/cc @pchojnacki 