### PR TITLE
PLATFORM-1331 Make vignette ask Image review service for static-assets images status

### DIFF
--- a/src/vignette/setup.clj
+++ b/src/vignette/setup.clj
@@ -6,7 +6,7 @@
             [vignette.storage.s3 :refer [create-s3-storage-system storage-creds]]
             [vignette.storage.core :refer [create-image-storage]]
             [vignette.storage.local :refer [create-local-storage-system]]
-            [vignette.util.static-assets :refer [materialize-static-asset-url]]
+            [vignette.util.services :refer [materialize-static-asset-url materialize-image-review-url]]
             [vignette.storage.static-assets :refer [create-static-image-storage]]))
 
 
@@ -19,7 +19,7 @@
 
 (defn create-stores [opts]
   {:wikia-store  (create-image-storage (create-object-storage opts) (:cache-thumbnails opts))
-   :static-store (create-static-image-storage materialize-static-asset-url)
+   :static-store (create-static-image-storage materialize-static-asset-url materialize-image-review-url)
    })
 
 (defn image-routes [stores]

--- a/src/vignette/storage/static_assets.clj
+++ b/src/vignette/storage/static_assets.clj
@@ -24,7 +24,7 @@
 
 (defn create-async-response-stored-object [static-image-get image-review-get]
   (let [static-image-response @static-image-get]
-    (if (and (-> static-image-response :status (= 200)) (-> @image-review-get :status (= 200)) )
+    (if (and (-> static-image-response :status (= 200)) (-> @image-review-get :status (= 200)))
       (->AsyncResponseStoredObject static-image-response))))
 
 (defrecord StaticImageStorage [static-image-url image-review-url] ImageStorageProtocol
@@ -40,7 +40,9 @@
 
   (original-exists? [_ image-map] nil
     (if-let [uuid (:uuid image-map)]
-      (let [response @(http/head (static-image-url uuid))] (-> response :status (= 200))))))
+      (let [static-image-response (http/head (static-image-url uuid)) image-review-response (http/get (image-review-url uuid))]
+        (and (-> @static-image-response :status (= 200))
+             (-> @image-review-response :status (= 200)))))))
 
 (defn create-static-image-storage [static-image-url image-review-url]
   (->StaticImageStorage static-image-url image-review-url))

--- a/src/vignette/storage/static_assets.clj
+++ b/src/vignette/storage/static_assets.clj
@@ -23,9 +23,9 @@
   (->response-object [this] (file-stream this)))
 
 (defn create-async-response-stored-object [static-image-get image-review-get]
-  (let [response @static-image-get]
-    (if (-> response :status (= 200))
-      (->AsyncResponseStoredObject response))))
+  (let [static-image-response @static-image-get]
+    (if (and (-> static-image-response :status (= 200)) (-> @image-review-get :status (= 200)) )
+      (->AsyncResponseStoredObject static-image-response))))
 
 (defrecord StaticImageStorage [static-image-url image-review-url] ImageStorageProtocol
   (save-thumbnail [_ _ _] nil)

--- a/src/vignette/storage/static_assets.clj
+++ b/src/vignette/storage/static_assets.clj
@@ -24,7 +24,7 @@
 
 (defn create-async-response-stored-object [static-image-get image-review-get]
   (let [static-image-response @static-image-get]
-    (if (and (-> static-image-response :status (= 200)) (-> @image-review-get :status (= 200)))
+    (if (and (-> static-image-response :status (= 200)) (some #(= % (:status @image-review-get)) [200 404]))
       (->AsyncResponseStoredObject static-image-response))))
 
 (defrecord StaticImageStorage [static-image-url image-review-url] ImageStorageProtocol
@@ -42,7 +42,7 @@
     (if-let [uuid (:uuid image-map)]
       (let [static-image-response (http/head (static-image-url uuid)) image-review-response (http/head (image-review-url uuid))]
         (and (-> @static-image-response :status (= 200))
-             (-> @image-review-response :status (= 200)))))))
+             (-> @image-review-response :status (some-fn #(or (= % 200) (= % 404)))))))))
 
 (defn create-static-image-storage [static-image-url image-review-url]
   (->StaticImageStorage static-image-url image-review-url))

--- a/src/vignette/storage/static_assets.clj
+++ b/src/vignette/storage/static_assets.clj
@@ -40,7 +40,7 @@
 
   (original-exists? [_ image-map] nil
     (if-let [uuid (:uuid image-map)]
-      (let [static-image-response (http/head (static-image-url uuid)) image-review-response (http/get (image-review-url uuid))]
+      (let [static-image-response (http/head (static-image-url uuid)) image-review-response (http/head (image-review-url uuid))]
         (and (-> @static-image-response :status (= 200))
              (-> @image-review-response :status (= 200)))))))
 

--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -98,5 +98,4 @@
     (try
       (digest/sha1 (fully-qualified-original-path image-map))
       (catch Exception e
-        (print e)
         (str "vignette-" (:original image-map))))))

--- a/src/vignette/util/services.clj
+++ b/src/vignette/util/services.clj
@@ -1,0 +1,16 @@
+(ns vignette.util.services
+  (:require [vignette.util.consul :as consul]
+            [environ.core :refer [env]]))
+
+(defn materialize-static-asset-url [oid]
+  (str
+    (consul/->uri
+      (consul/find-service
+        consul/create-consul "static-assets" consul/service-query-tag)) "/image/" oid))
+
+(defn materialize-image-review-url [oid & statuses]
+  ;(let [status-query (empty? statuses))
+  (str
+    (consul/->uri
+      (consul/find-service
+        consul/create-consul "image-review" consul/service-query-tag)) "/image-review/image/" oid "?"))

--- a/src/vignette/util/services.clj
+++ b/src/vignette/util/services.clj
@@ -1,5 +1,6 @@
 (ns vignette.util.services
   (:require [vignette.util.consul :as consul]
+            [clojure.string :refer [join]]
             [environ.core :refer [env]]))
 
 (defn materialize-static-asset-url [oid]
@@ -9,8 +10,8 @@
         consul/create-consul "static-assets" consul/service-query-tag)) "/image/" oid))
 
 (defn materialize-image-review-url [oid & statuses]
-  ;(let [status-query (empty? statuses))
-  (str
-    (consul/->uri
-      (consul/find-service
-        consul/create-consul "image-review" consul/service-query-tag)) "/image-review/image/" oid "?"))
+  (let [query-params (str "status=" (if (empty? statuses) (join "&status=" ["FLAGGED" "UNREVIEWED"]) (join "&" statuses)))]
+    (str
+      (consul/->uri
+        (consul/find-service
+          consul/create-consul "image-review" consul/service-query-tag)) "/image-review/image/" oid "?" query-params)))

--- a/src/vignette/util/services.clj
+++ b/src/vignette/util/services.clj
@@ -10,7 +10,7 @@
         consul/create-consul "static-assets" consul/service-query-tag)) "/image/" oid))
 
 (defn materialize-image-review-url [oid & statuses]
-  (let [query-params (str "status=" (if (empty? statuses) (join "&status=" ["FLAGGED" "UNREVIEWED"]) (join "&" statuses)))]
+  (let [query-params (str "status=" (if (empty? statuses) (join "&status=" ["ACCEPTED" "FLAGGED" "UNREVIEWED"]) (join "&" statuses)))]
     (str
       (consul/->uri
         (consul/find-service

--- a/src/vignette/util/static_assets.clj
+++ b/src/vignette/util/static_assets.clj
@@ -1,9 +1,0 @@
-(ns vignette.util.static-assets
-  (:require [vignette.util.consul :as consul]
-            [environ.core :refer [env]]))
-
-(defn materialize-static-asset-url [oid]
-  (str
-    (consul/->uri
-      (consul/find-service
-        consul/create-consul "static-assets" consul/service-query-tag)) "/image/" oid))

--- a/test/vignette/storage/static_assets_test.clj
+++ b/test/vignette/storage/static_assets_test.clj
@@ -15,6 +15,14 @@
          (http/get ..image-review-url..) => (future {:status 200})
          (sa/->AsyncResponseStoredObject {:status 200}) => ..object..)
        (get-original
+         (sa/create-static-image-storage --static-asset-get-- --image-review-get--) {:uuid ..uuid..}) => ..object..
+       (provided
+         (--static-asset-get-- ..uuid..) => ..static-asset-url..
+         (--image-review-get-- ..uuid..) => ..image-review-url..
+         (http/get ..static-asset-url.. {:as :stream}) => (future {:status 200})
+         (http/get ..image-review-url..) => (future {:status 404})
+         (sa/->AsyncResponseStoredObject {:status 200}) => ..object..)
+       (get-original
          (sa/create-static-image-storage --static-asset-get-- --image-review-get--) {:uuid ..uuid..}) => nil
        (provided
          (--static-asset-get-- ..uuid..) => ..static-asset-url..
@@ -27,7 +35,7 @@
          (--static-asset-get-- ..uuid..) => ..static-asset-url..
          (--image-review-get-- ..uuid..) => ..image-review-url..
          (http/get ..static-asset-url.. {:as :stream}) => (future {:status 200})
-         (http/get ..image-review-url..) => (future {:status 404})))
+         (http/get ..image-review-url..) => (future {:status 401})))
 
 (facts :static-assets :filename
        (filename

--- a/test/vignette/storage/static_assets_test.clj
+++ b/test/vignette/storage/static_assets_test.clj
@@ -7,16 +7,27 @@
 
 (facts :static-assets :get-original
        (get-original
-         (sa/create-static-image-storage --url-get--) {:uuid ..uuid..}) => ..object..
+         (sa/create-static-image-storage --static-asset-get-- --image-review-get--) {:uuid ..uuid..}) => ..object..
        (provided
-         (--url-get-- ..uuid..) => ..url..
-         (http/get ..url.. {:as :stream}) => (future {:status 200})
+         (--static-asset-get-- ..uuid..) => ..static-asset-url..
+         (--image-review-get-- ..uuid..) => ..image-review-url..
+         (http/get ..static-asset-url.. {:as :stream}) => (future {:status 200})
+         (http/get ..image-review-url..) => (future {:status 200})
          (sa/->AsyncResponseStoredObject {:status 200}) => ..object..)
        (get-original
-         (sa/create-static-image-storage --url-get--) {:uuid ..uuid..}) => nil
+         (sa/create-static-image-storage --static-asset-get-- --image-review-get--) {:uuid ..uuid..}) => nil
        (provided
-         (--url-get-- ..uuid..) => ..url..
-         (http/get ..url.. {:as :stream}) => (future {:status 404})))
+         (--static-asset-get-- ..uuid..) => ..static-asset-url..
+         (--image-review-get-- ..uuid..) => ..image-review-url..
+         (http/get ..static-asset-url.. {:as :stream}) => (future {:status 404})
+         (http/get ..image-review-url..) => (future {:status 200}))
+       (get-original
+         (sa/create-static-image-storage --static-asset-get-- --image-review-get--) {:uuid ..uuid..}) => nil
+       (provided
+         (--static-asset-get-- ..uuid..) => ..static-asset-url..
+         (--image-review-get-- ..uuid..) => ..image-review-url..
+         (http/get ..static-asset-url.. {:as :stream}) => (future {:status 200})
+         (http/get ..image-review-url..) => (future {:status 404})))
 
 (facts :static-assets :filename
        (filename

--- a/test/vignette/util/image_response_test.clj
+++ b/test/vignette/util/image_response_test.clj
@@ -1,31 +1,31 @@
 (ns vignette.util.image-response-test
- (:require [clojure.java.io :as io]
-           [clout.core :refer (route-compile route-matches)]
-           [midje.sweet :refer :all]
-           [ring.mock.request :refer :all]
-           [vignette.test.helper :refer [context-route-matches]]
-           [vignette.http.route-helpers :refer :all]
-           [vignette.http.proto-routes :as proto]
-           [vignette.util.image-response :refer :all]
-           [vignette.storage.core :refer :all]
-           [vignette.storage.local :refer [create-stored-object]]
-           [vignette.util.image-response :as ir]
-           [ring.util.codec :refer [url-encode]]))
+  (:require [clojure.java.io :as io]
+            [clout.core :refer (route-compile route-matches)]
+            [midje.sweet :refer :all]
+            [ring.mock.request :refer :all]
+            [vignette.test.helper :refer [context-route-matches]]
+            [vignette.http.route-helpers :refer :all]
+            [vignette.http.proto-routes :as proto]
+            [vignette.util.image-response :refer :all]
+            [vignette.storage.core :refer :all]
+            [vignette.storage.local :refer [create-stored-object]]
+            [vignette.util.image-response :as ir]
+            [ring.util.codec :refer [url-encode]]))
 
 (def in-wiki-context-route-matches (partial context-route-matches vignette.http.api-routes/wiki-context))
 
 (facts :create-image-response
-  (let [image-map 
-        (route->original-map (in-wiki-context-route-matches
-                               proto/original-route
-                               (request :get "/lotr/3/35/ropes.jpg/revision/latest"))
-                             {})
-        response (create-image-response (create-stored-object "image-samples/ropes.jpg")  image-map)
-        response-headers (:headers response)]
-    (get response-headers "Surrogate-Key") => "7d1d24f2c2af364882953e8c97bf90092c2f7a08"
-    (get response-headers "Content-Disposition") => "inline; filename=\"ropes.jpg\"; filename*=UTF-8''ropes.jpg"
-    (get response-headers "Content-Length") => "23"
-    (get response-headers "ETag") => "c1cfdb01ca32d56c29cf349af37a6779"))
+       (let [image-map
+             (route->original-map (in-wiki-context-route-matches
+                                    proto/original-route
+                                    (request :get "/lotr/3/35/ropes.jpg/revision/latest"))
+                                  {})
+             response (create-image-response (create-stored-object "image-samples/ropes.jpg") image-map)
+             response-headers (:headers response)]
+         (get response-headers "Surrogate-Key") => "7d1d24f2c2af364882953e8c97bf90092c2f7a08"
+         (get response-headers "Content-Disposition") => "inline; filename=\"ropes.jpg\"; filename*=UTF-8''ropes.jpg"
+         (get response-headers "Content-Length") => "23"
+         (get response-headers "ETag") => "c1cfdb01ca32d56c29cf349af37a6779"))
 
 (facts :add-content-disposition-header
        (add-content-disposition-header {} {:original "some-file.png"}) => {:headers {"Content-Disposition" "inline; filename=\"some-file.png\"; filename*=UTF-8''some-file.png"}}
@@ -35,3 +35,9 @@
 (facts :when-header-val
        (when-header-val {} "Content-Type" nil) => {}
        (when-header-val {} "Content-Type" "type") => {:headers {"Content-Type" "type"}})
+
+(facts :add-surrogate-key-header
+       (add-surrogate-header {} {:uuid "123"}) => {:headers {"Surrogate-Key" "123", "X-Surrogate-Key" "123"}}
+       (add-surrogate-header {} {:wikia "wikia" :original "orig" :image-type "images"}) =>
+       {:headers {"Surrogate-Key"   "c8dfba77e9beb5c26ca20d4411674065d4a0ded5"
+                  "X-Surrogate-Key" "c8dfba77e9beb5c26ca20d4411674065d4a0ded5"}})

--- a/test/vignette/util/services_test.clj
+++ b/test/vignette/util/services_test.clj
@@ -6,18 +6,9 @@
 (facts :static-assets :url
        (svc/materialize-static-asset-url "uuid_sample") => "http://hostname:9999/image/uuid_sample"
        (provided
-         (consul/find-service consul/create-consul "static-assets" "prod") => {:address "hostname", :port 9999})
-       (consul/create-consul ..dupa..) => ..aaa..)
+         (consul/find-service consul/create-consul "static-assets" "prod") => {:address "hostname", :port 9999}))
 
-;(defn materialize-static-asset-url [oid]
-;  (str
-;    (consul/->uri
-;      (consul/find-service
-;        consul/create-consul "static-assets" consul/service-query-tag)) "/image/" oid))
-;
-;(defn materialize-image-review-url [oid & statuses]
-;  (let [query-params (str "status=" (if (empty? statuses) (join "&status=" ["FLAGGED" "UNREVIEWED"]) (join "&" statuses)))]
-;    (str
-;      (consul/->uri
-;        (consul/find-service
-;          consul/create-consul "image-review" consul/service-query-tag)) "/image-review/image/" oid "?" query-params)))
+(facts :image-review :url
+       (svc/materialize-image-review-url "uuid_sample") => "http://hostname:9999/image-review/image/uuid_sample?status=ACCEPTED&status=FLAGGED&status=UNREVIEWED"
+       (provided
+         (consul/find-service consul/create-consul "image-review" "prod") => {:address "hostname", :port 9999}))

--- a/test/vignette/util/services_test.clj
+++ b/test/vignette/util/services_test.clj
@@ -1,0 +1,23 @@
+(ns vignette.util.services-test
+  (:require [midje.sweet :refer :all]
+            [vignette.util.services :as svc]
+            [vignette.util.consul :as consul]))
+
+(facts :static-assets :url
+       (svc/materialize-static-asset-url "uuid_sample") => "http://hostname:9999/image/uuid_sample"
+       (provided
+         (consul/find-service consul/create-consul "static-assets" "prod") => {:address "hostname", :port 9999})
+       (consul/create-consul ..dupa..) => ..aaa..)
+
+;(defn materialize-static-asset-url [oid]
+;  (str
+;    (consul/->uri
+;      (consul/find-service
+;        consul/create-consul "static-assets" consul/service-query-tag)) "/image/" oid))
+;
+;(defn materialize-image-review-url [oid & statuses]
+;  (let [query-params (str "status=" (if (empty? statuses) (join "&status=" ["FLAGGED" "UNREVIEWED"]) (join "&" statuses)))]
+;    (str
+;      (consul/->uri
+;        (consul/find-service
+;          consul/create-consul "image-review" consul/service-query-tag)) "/image-review/image/" oid "?" query-params)))


### PR DESCRIPTION
To allow more flexibility in review process we decided to implement filtering of rejected static-asset images in vignette.
This change makes static-assets handling code to at the same time ask two services then resolve both responses  asynchronously and check if both services return proper responses.

Additionally, static assets images were missing SurrogateKey which this change also adds.

/cc:
@drsnyder @nmonterroso