### PR TITLE
PLATFORM-1805: Fix top-crop-down when requested size is smaller than original image

### DIFF
--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -298,28 +298,35 @@ function recalculate_requested_size_for_crop_down() {
 	# need to use bc for floating-point arithmetic below
 	local CODE=`cat <<EOF
 scale = 20
-define i(x) {
-    auto s
-    s = scale
+define trunc(x) {
+    auto saved_scale
+    saved_scale = scale
     scale = 0
     x /= 1   /* round x down */
-    scale = s
+    scale = saved_scale
     return (x)
 }
 
-s = 1
-u = $origwidth / $WIDTH
-if (u<s) s = u
+define round(x) {
+	x += 0.5 /* round */
+	x += 0.000000001 /* epsilon */
+	return trunc(x)
+}
 
-u = $origheight / $HEIGHT
-if (u<s) s = u
+min_acceptable_scale = 1
+candidate_scale = $origwidth / $WIDTH
+if (candidate_scale < min_acceptable_scale) min_acceptable_scale = candidate_scale
 
-i($WIDTH * s + 0.000000001)
-i($HEIGHT * s + 0.000000001)
+candidate_scale = $origheight / $HEIGHT
+if (candidate_scale < min_acceptable_scale) min_acceptable_scale = candidate_scale
 
-s
-$WIDTH * s
-$HEIGHT * s
+round($WIDTH * min_acceptable_scale)
+round($HEIGHT * min_acceptable_scale)
+
+/* debug information - ignored on production */
+min_acceptable_scale
+$WIDTH * min_acceptable_scale
+$HEIGHT * min_acceptable_scale
 EOF
 `
 	local CALCOUT=`echo "$CODE" | bc`

--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -285,6 +285,49 @@ function set_custom_type() {
 	OUT="${1}:${OUT}"
 }
 
+function recalculate_requested_size_for_crop_down() {
+	# recalculate output image dimensions in cases of "...-crop-down" modes
+	# in such a way that an output image has the same aspect ratio as request
+	# after executing imagemagick
+	local origwidth=$1
+	local origheight=$2
+	local CODE
+	local x
+	local y
+
+	# need to use bc for floating-point arithmetic below
+	local CODE=`cat <<EOF
+scale = 20
+define i(x) {
+    auto s
+    s = scale
+    scale = 0
+    x /= 1   /* round x down */
+    scale = s
+    return (x)
+}
+
+s = 1
+u = $origwidth / $WIDTH
+if (u<s) s = u
+
+u = $origheight / $HEIGHT
+if (u<s) s = u
+
+i($WIDTH * s + 0.000000001)
+i($HEIGHT * s + 0.000000001)
+
+s
+$WIDTH * s
+$HEIGHT * s
+EOF
+`
+	local CALCOUT=`echo "$CODE" | bc`
+
+	WIDTH=`echo "$CALCOUT" | head -n 1`
+	HEIGHT=`echo "$CALCOUT" | head -n 2 | tail -n 1`
+}
+
 function thumb_params() {
 	QUALITY=''
 
@@ -360,10 +403,9 @@ function thumb_params() {
 			echo "Height ${origheight} x Width ${origwidth}"
 			if [[ $origheight -gt $HEIGHT && $origwidth -gt $WIDTH ]]; then
 				THUMB_PARAMS="${QUALITY} -thumbnail ${WIDTH}x${HEIGHT}+0+0^ -gravity north -crop ${WIDTH}x${HEIGHT}+0+0!"
-			elif [ $origheight -gt $HEIGHT ] || [ $origwidth -gt $WIDTH ]; then
-				THUMB_PARAMS="${QUALITY} -gravity north -crop ${WIDTH}x${HEIGHT}+0+0! -thumbnail ${WIDTH}x${HEIGHT}+0+0"
 			else
-				THUMB_PARAMS="${QUALITY}"
+				recalculate_requested_size_for_crop_down $origwidth $origheight
+				THUMB_PARAMS="${QUALITY} -gravity north -crop ${WIDTH}x${HEIGHT}+0+0 -thumbnail ${WIDTH}x${HEIGHT}+0+0"
 			fi
 			;;
 		"window-crop")
@@ -391,10 +433,9 @@ function thumb_params() {
 			echo "Height ${origheight} x Width ${origwidth}"
 			if [[ $origheight -gt $HEIGHT && $origwidth -gt $WIDTH ]]; then
 				THUMB_PARAMS="${QUALITY} -thumbnail ${WIDTH}x${HEIGHT}+0+0^ -gravity center -crop ${WIDTH}x${HEIGHT}+0+0!"
-			elif [ $origheight -gt $HEIGHT ] || [ $origwidth -gt $WIDTH ]; then
-				THUMB_PARAMS="${QUALITY} -gravity center -crop ${WIDTH}x${HEIGHT}+0+0! -thumbnail ${WIDTH}x${HEIGHT}+0+0"
 			else
-				THUMB_PARAMS="${QUALITY}"
+				recalculate_requested_size_for_crop_down $origwidth $origheight
+				THUMB_PARAMS="${QUALITY} -gravity center -crop ${WIDTH}x${HEIGHT}+0+0 -thumbnail ${WIDTH}x${HEIGHT}+0+0"
 			fi
 			;;
 	esac
@@ -475,4 +516,4 @@ function thumb() {
 	fi
 }
 
-thumb 
+thumb


### PR DESCRIPTION
Theoretically behavior for "top-crop-down" and "zoom-crop-down" was unspecified when requested dimensions were smaller than those of the original image. Practically the output was a cropped image but the image dimensions ratio was changed in a non-intuitive (and non-practical) way.

This change brings a bit more of sanity into this use case. The highest priority in the current implementation is to preserve the ratio of the requested dimensions.

https://wikia-inc.atlassian.net/browse/PLATFORM-1805

/cc @drsnyder @nmonterroso @SzymonCierniewski @pchojnacki 