### PR TITLE
PLATFORM-1808 Fix file extension handling 

### DIFF
--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -104,15 +104,10 @@
              :response-code 404}
             "unable to get original for thumbnailing")))
 
-(defn- extract-extension [filename]
-  (if filename
-    (last (rest (split filename #"\.")))
-    ""))
-
 (defn original->local
   "Take the original and make it local."
   [original]
-  (let [temp-file (io/file (temp-filename nil (extract-extension (filename original))))]
+  (let [temp-file (io/file (temp-filename nil (file-extension (filename original))))]
     (when (transfer! original temp-file)
       temp-file)))
 

--- a/test/vignette/util/filesystem_test.clj
+++ b/test/vignette/util/filesystem_test.clj
@@ -4,4 +4,5 @@
 
 (facts :file-extension
        (file-extension "some-file.png") => "png"
+       (file-extension "Mambo No. 5 (A Little Bit of...)") => nil
        (file-extension "some-file.png.jpg") => "jpg")

--- a/test/vignette/util/thumbnail_test.clj
+++ b/test/vignette/util/thumbnail_test.clj
@@ -46,6 +46,21 @@
        (.getName (original->local
                    (ls/create-stored-object (io/file "LICENSE")))) => (just #"[-0-9a-f]{36}"))
 
+(facts :orignal->local-handles-no-file-extension-with-invalid-chars
+       (original->local ..stored-object..) => ..tmp-file..
+       (provided
+         (filename ..stored-object..) => "LICEN.S#().)_E"
+         (io/file (temp-filename nil nil)) => ..tmp-file..
+         (transfer! ..stored-object.. ..tmp-file..) => ..tmp-file..))
+
+(facts :orignal->local-handles-file-exension-with-valid-chars
+       (original->local ..stored-object..) => ..tmp-file..
+       (provided
+         (filename ..stored-object..) => "LICEN.S#().Ejpg"
+         (io/file (temp-filename nil "Ejpg")) => ..tmp-file..
+         (transfer! ..stored-object.. ..tmp-file..) => ..tmp-file..))
+
+
 (facts :generate-thumbnail
        (generate-thumbnail ..store.. beach-map) => ..object..
        (provided


### PR DESCRIPTION
some junk filenames caused junk file extension to be used on filesystem.
This PR fixes it by only allowing ([a-z_A-Z0-9]*) in file extension otherwise the extension will be treated as nil.