### PR TITLE
SER-81 thumb verifier rounding error fix

### DIFF
--- a/src/vignette/util/thumb_verifier.clj
+++ b/src/vignette/util/thumb_verifier.clj
@@ -8,7 +8,8 @@
   thumb-size-estimators
   estimate-thumb-size
   size-of
-  not-close-in-size)
+  not-close-in-size
+  area-ratio)
 
 (defn check-thumb-size
   "Checks if the generated thumbnail has the correct size.
@@ -24,6 +25,7 @@
                   :thumb-map thumb-map
                   :estimated estimated-size
                   :actual thumb-size
+                  :area-ratio (area-ratio thumb-size estimated-size)
                   })))
       (log/error "Couldn't verify thumbnail size. No estimator found." {
         :thumb-map thumb-map
@@ -39,6 +41,16 @@
   (let [dw (Math/abs (- (:width estimated) (:width actual 0)))
         dh (Math/abs (- (:height estimated) (:height actual 0)))]
     (or (< 1 dw) (< 1 dh))))
+
+(defn area
+  [dimentions]
+  (* (:width dimentions 0) (:height dimentions 0)))
+
+(defn area-ratio
+  [actual estimated]
+  (let [actual-area (area actual)
+        estimated-area (area estimated)]
+    (if (zero? estimated-area) 0.0 (float (/ actual-area estimated-area)))))
 
 (def identify-bin
   (trim (str (env :imagemagick-base "/usr/local") "/bin/identify")))

--- a/src/vignette/util/thumb_verifier.clj
+++ b/src/vignette/util/thumb_verifier.clj
@@ -22,16 +22,16 @@
             estimated-size (estimate-thumb-size estimator thumb-map original)]
               (if (not-close-in-size estimated-size thumb-size)
                 (log/error "Thumbnail size is incorrect!" {
-                  :thumb-map thumb-map
+                  :thumb_map thumb-map
                   :estimated estimated-size
                   :actual thumb-size
-                  :area-ratio (area-ratio thumb-size estimated-size)
+                  :area_ratio (area-ratio thumb-size estimated-size)
                   })))
       (log/error "Couldn't verify thumbnail size. No estimator found." {
-        :thumb-map thumb-map
+        :thumb_map thumb-map
         }))
     (catch Exception e (log/error (str "Thumbnail verification failed - " e) {
-      :thumb-map thumb-map
+      :thumb_map thumb-map
       }))))
 
 (defn not-close-in-size

--- a/src/vignette/util/thumb_verifier.clj
+++ b/src/vignette/util/thumb_verifier.clj
@@ -7,7 +7,8 @@
 (declare
   thumb-size-estimators
   estimate-thumb-size
-  size-of)
+  size-of
+  not-close-in-size)
 
 (defn check-thumb-size
   "Checks if the generated thumbnail has the correct size.
@@ -18,7 +19,7 @@
               (thumb-size-estimators (keyword (:thumbnail-mode thumb-map)))]
       (let [thumb-size (size-of thumb)
             estimated-size (estimate-thumb-size estimator thumb-map original)]
-              (if (not= estimated-size thumb-size)
+              (if (not-close-in-size estimated-size thumb-size)
                 (log/error "Thumbnail size is incorrect!" {
                   :thumb-map thumb-map
                   :estimated estimated-size
@@ -30,6 +31,14 @@
     (catch Exception e (log/error (str "Thumbnail verification failed - " e) {
       :thumb-map thumb-map
       }))))
+
+(defn not-close-in-size
+  "Checks if the given dimentions are different,
+  assuming there may be a rounding error"
+  [estimated actual]
+  (let [dw (Math/abs (- (:width estimated) (:width actual 0)))
+        dh (Math/abs (- (:height estimated) (:height actual 0)))]
+    (or (< 1 dw) (< 1 dh))))
 
 (def identify-bin
   (trim (str (env :imagemagick-base "/usr/local") "/bin/identify")))

--- a/test/vignette/util/thumb_verifier_test.clj
+++ b/test/vignette/util/thumb_verifier_test.clj
@@ -94,3 +94,10 @@
   (verify/not-close-in-size {:width 100 :height 100}
                             {:width 100 :height 102})
     => true)
+
+(facts :area-ratio
+  (verify/area-ratio {} {:width 100 :height 100}) => 0.0
+  (verify/area-ratio {:width 100 :height 100} {:width 100 :height 0}) => 0.0
+  (verify/area-ratio {:width 100 :height 100} {:width 100 :height 100}) => 1.0
+  (verify/area-ratio {:width 150 :height 100} {:width 100 :height 100}) => 1.5
+  (verify/area-ratio {:width 50 :height 100} {:width 100 :height 100}) => 0.5)

--- a/test/vignette/util/thumb_verifier_test.clj
+++ b/test/vignette/util/thumb_verifier_test.clj
@@ -65,3 +65,32 @@
   (verify/scale-and-fit-in-original {:width 150 :height 250}
                                     {:width 100 :height 100})
     => {:width 100 :height 100})
+
+(facts :not-close-in-size
+  (verify/not-close-in-size {:width 100 :height 100}
+                            {:width 100 :height 100})
+    => false
+  (verify/not-close-in-size {:width 100 :height 100}
+                            {:width 101 :height 100})
+    => false
+  (verify/not-close-in-size {:width 100 :height 100}
+                            {:width 99 :height 100})
+    => false
+  (verify/not-close-in-size {:width 100 :height 100}
+                            {:width 100 :height 101})
+    => false
+  (verify/not-close-in-size {:width 100 :height 100}
+                            {:width 100 :height 99})
+    => false
+  (verify/not-close-in-size {:width 100 :height 100}
+                            {:width 101 :height 101})
+    => false
+  (verify/not-close-in-size {:width 100 :height 100}
+                            {:width 99 :height 99})
+    => false
+  (verify/not-close-in-size {:width 100 :height 100}
+                            {:width 102 :height 100})
+    => true
+  (verify/not-close-in-size {:width 100 :height 100}
+                            {:width 100 :height 102})
+    => true)


### PR DESCRIPTION
[Ticket](https://wikia-inc.atlassian.net/browse/SER-81)

This PR fixes the rounding error issue (too many false positives in error log) and introduces the `area_ratio` field for easier log filtering.