### PR TITLE
PLATFORM-2660: log request details (path, format, image size, headers))

### DIFF
--- a/src/vignette/http/middleware.clj
+++ b/src/vignette/http/middleware.clj
@@ -5,6 +5,7 @@
             [ring.util.response :refer [response status charset header get-header]]
             [slingshot.slingshot :refer [try+ throw+]]
             [vignette.util.image-response :refer :all]
+            [vignette.util.query-options :refer :all]
             [wikia.common.logger :as log]
             [wikia.common.perfmonitoring.core :as perf])
   (:import [java.net InetAddress]))
@@ -40,6 +41,19 @@
 
 (declare add-cache-control-header
          hours-to-seconds)
+
+(defn log-image-request
+  [handler]
+  (fn [request]
+    (let [response (handler request)]
+      (log/warn "Image request" {:status (get response :status 0)
+                             :uri (:uri request)
+                             :format (get (:query-params request) "format")
+                             :accept (get (:headers request) "accept")
+                             :agent (get (:headers request) "user-agent")
+                             :size (get (:headers response) "Content-Length" "0")
+                             })
+      response)))
 
 (defn add-headers
   [handler]

--- a/src/vignette/http/routes.clj
+++ b/src/vignette/http/routes.clj
@@ -18,6 +18,7 @@
                         (GET "/ping" [] "pong")
                         (files "/static/")
                         (bad-request-path))))
+      (log-image-request)
       (wrap-params)
       (exception-catcher)
       (multiple-slash->single-slash)


### PR DESCRIPTION
Logging the details of the requests so we can check (based on the accept headers and user agents) what % of the request could accept webp format.

@pwojcik86 