### PR TITLE
SER-753 placeholders for blocked images

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,3 +291,4 @@ Distributed under the Eclipse Public License either version 1.0 or (at your opti
  * [Michał Roszka](https://github.com/michalroszka)
  * [Nelson Monterroso](https://github.com/nmonterroso)
  * [Pawel Chojnacki](https://github.com/pchojnacki)
+ * [Paweł Wójcik](https://github.com/pwojcik86)

--- a/src/vignette/http/route_helpers.clj
+++ b/src/vignette/http/route_helpers.clj
@@ -7,6 +7,7 @@
             [vignette.storage.protocols :refer :all]
             [vignette.util.thumbnail :as u]))
 
+(def blocked-placeholder-param "bp")
 
 (defn handle-thumbnail
   [store image-params request]
@@ -43,12 +44,21 @@
   [request-map]
   (assoc request-map :image-type (route-params->image-type request-map)))
 
+(defn route->blocked-placeholder
+  [request-map request]
+  (if-let [params (:query-params request)]
+    (if-let [placeholder-id (params blocked-placeholder-param)]
+      (assoc request-map :blocked-placeholder placeholder-id)
+      request-map)
+    request-map))
+
 (defn route->original-map
   [request-map request]
   (-> request-map
       (assoc :request-type :original)
       (route->image-type)
-      (route->options request)))
+      (route->options request)
+      (route->blocked-placeholder request)))
 
 (defn route->thumbnail-map
   [request-map request &[options]]
@@ -56,6 +66,7 @@
       (assoc :request-type :thumbnail)
       (route->image-type)
       (route->options request)
+      (route->blocked-placeholder request)
       (cond->
         options (merge options))))
 

--- a/src/vignette/storage/static_assets.clj
+++ b/src/vignette/storage/static_assets.clj
@@ -34,8 +34,13 @@
 
   (get-original [_ original-map]
     (if-let [uuid (:uuid original-map)]
-      (create-async-response-stored-object
-        (http/get (static-image-url uuid) {:as :stream}))))
+      (let [response @(http/get (static-image-url uuid) {:as :stream})]
+        (let [status (:status response)]
+          (if (= 200 status)
+            (->AsyncResponseStoredObject response)
+            (if (= 451 status)
+              (if-let [pid (:blocked-placeholder original-map)]
+                (create-async-response-stored-object (http/get (static-image-url pid) {:as :stream})))))))))
 
   (original-exists? [_ image-map] nil
     (if-let [uuid (:uuid image-map)]

--- a/test/vignette/storage/static_assets_test.clj
+++ b/test/vignette/storage/static_assets_test.clj
@@ -33,3 +33,13 @@
          ..response.. =contains=> {:headers {}})
        (filename
          (sa/->AsyncResponseStoredObject ..response..)) => nil)
+
+(facts :static-assets :get-blocked-placeholder
+       (get-original
+         (sa/create-static-image-storage --static-asset-get--) {:uuid ..uuid.. :blocked-placeholder ..placeholder-id..}) => ..placeholder..
+       (provided
+         (--static-asset-get-- ..uuid..) => ..static-asset-url..
+         (http/get ..static-asset-url.. {:as :stream}) => (future {:status 451})
+         (--static-asset-get-- ..placeholder-id..) => ..placeholder-url..
+         (http/get ..placeholder-url.. {:as :stream}) => (future {:status 200})
+         (sa/->AsyncResponseStoredObject {:status 200}) => ..placeholder..))


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SER-753

Adds a new optional query parameter `bp` that must contain a `static-assets` image id. If the requested `static-assets` image is blocked, Vignette will return the placeholder instead. All requested transformations will be applied to the placeholder.

//cc @Wikia/services-team 