### PR TITLE
PLATFORM-2892: Fix uploading thumbnailer results back to s3

### DIFF
--- a/src/vignette/storage/local.clj
+++ b/src/vignette/storage/local.clj
@@ -40,7 +40,7 @@
   (list-buckets [this])
   (list-objects [this bucket]))
 
-(defrecord LocalStoredObject [file stream-close-callbacks]
+(defrecord LocalStoredObject [file]
   StoredObjectProtocol
   (file-stream [this]
     (:file this))
@@ -52,12 +52,7 @@
     (digest/md5 (file-stream this)))
   (filename [this] (.getName (:file this)))
   (->response-object [this]
-    (let [file (file-stream this)
-          stored-object this]
-      (proxy [FileInputStream] [file]
-        (close []
-          (proxy-super close)
-          (doall (map #(% stored-object) (:stream-close-callbacks stored-object)))))))
+    (file-stream this))
   (transfer! [this to]
     (io/copy (file-stream this)
              (io/file to))
@@ -68,5 +63,5 @@
   (->LocalStorageSystem directory))
 
 (defn create-stored-object
-  [file & callbacks]
-  (->LocalStoredObject file callbacks))
+  [file]
+    (->LocalStoredObject file))

--- a/src/vignette/storage/local.clj
+++ b/src/vignette/storage/local.clj
@@ -64,4 +64,4 @@
 
 (defn create-stored-object
   [file]
-    (->LocalStoredObject file))
+  (->LocalStoredObject file))


### PR DESCRIPTION
Revert some old changes in order to fix the thumbnailer results uploads to s3.

We were hooking into stream close event to upload the files from `/tmp/vignette` to s3. Unfortunately that stream is not closed when the response is server, so the only scenario in which the images were uploaded was when the object were garbage-collected early enough (before the files were removed from `/tmp` which happens every 10 minutes).

In this change I'm uploading the files to s3 in parallel to serving the response. As a results I cannot delete the file from `/tmp` in the code, but those are cleaned up anyway by a cron job.
