### PR TITLE
Platform-2899: Simplify the flow for full-size images

### DIFF
--- a/src/vignette/util/external_hotlinking.clj
+++ b/src/vignette/util/external_hotlinking.clj
@@ -17,24 +17,14 @@
   (if-let [vary-string (get-in request [:headers force-header-name])]
     (.contains vary-string force-header-val)))
 
-(defn force-webp? [image-params]
-  (= webp-format (get-in image-params [:options :format])))
-
 (defn image-params->forced-thumb-params [image-params]
   (merge image-params force-thumb-params))
 
 (defn image-params->forced-webp-params [image-params]
   (merge image-params force-webp-params))
 
-(defn webp-filter [store image-params]
-  (let [original-image (get-original store image-params)]
-    (if (and (force-webp? image-params)
-        (webp-or-compatible-mime-type? (content-type original-image)))
-          (u/original->get-or-generate-thumbnail store (image-params->forced-webp-params image-params) original-image)
-          original-image)))
-
 (defn original-request->file
   [request store image-params]
   (if (force-thumb? request)
     (u/get-or-generate-thumbnail store (image-params->forced-thumb-params image-params))
-    (webp-filter store image-params)))
+    (u/get-or-generate-thumbnail store (image-params->forced-webp-params image-params))))

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -21,7 +21,8 @@
          background-delete-file
          generate-thumbnail
          background-save-thumbnail
-         background-check-and-delete-original)
+         background-check-and-delete-original
+         webp-override)
 
 (def thumbnail-bin (env :vignette-thumbnail-bin (if (file-exists? "/usr/local/bin/thumbnail")
                                                   "/usr/local/bin/thumbnail"
@@ -37,8 +38,13 @@
 
 (def passthrough-mime-types #{"audio/ogg" "video/ogg"})
 (defn is-passthrough-required
-  [file]
-  (contains? passthrough-mime-types (mime-type-of (or file ""))))
+  [original thumb-map]
+  (let [original-mime-type (mime-type-of (or (filename original) ""))]
+    (or
+      (contains? passthrough-mime-types original-mime-type)
+      (and
+        (= "type-convert" (:thumbnail-mode thumb-map))
+        (empty? (get-in (webp-override original-mime-type thumb-map) [:options :format]))))))
 
 (defn route-map->thumb-args
   [thumb-map]
@@ -64,9 +70,6 @@
         thumb-options (reduce conj route-options query-options)
         args (reduce conj base-command thumb-options)
         sh-out (run-thumbnailer args)]
-    (log/error "Will call thumbnailer" {
-                                 :args args
-                                 })
     (cond
       (or (zero? (:exit sh-out))
           (and (= 1 (:exit sh-out))
@@ -77,12 +80,12 @@
                     "thumbnailing error"))))
 
 (defn webp-override
-  [original thumb-map]
+  [original-mime-type thumb-map]
   (if (and (= webp-format (get-in thumb-map [:options :format]))
-          (not (webp-compatible-mime-type? (mime-type-of (or original "")))))
-    (do
-      (log/info "webp-override-remove" (select-keys thumb-map [:original :options])) ; todo: do we need it?
-      (update-in thumb-map [:options] dissoc :format))
+           (not (webp-compatible-mime-type? original-mime-type)))
+      (do
+        (log/info "webp-override-remove" (select-keys thumb-map [:original :options])) ; todo: do we need it?
+        (update-in thumb-map [:options] dissoc :format))
       thumb-map)
 )
 
@@ -96,27 +99,17 @@
     (when-let [thumb (generate-thumbnail store thumb-map nil)]
     thumb)))
 
-(defn original->get-or-generate-thumbnail
-  [store thumb-map original]
-  (if-let [thumb (and (not (q/query-opt thumb-map :replace))
-                      (get-thumbnail store thumb-map))]
-    (do
-      (perf/publish {:thumbnail-cache-hit 1})
-      thumb)
-    (when-let [thumb (generate-thumbnail store thumb-map original)]
-      thumb)))
-
 (defn generate-thumbnail
   "Generate a thumbnail from the original specified in thumb-map.
   This function will download the original locally and thumbnail it.
   The original will be removed after the thumbnailing is completed."
   [store thumb-map original]
   (if-let [original (or original (get-original store thumb-map))]
-    (if (is-passthrough-required (filename original))
+    (if (is-passthrough-required original thumb-map)
       original
       (when-let [local-original (original->local original)]
         (try+
-          (let [thumb-params (webp-override local-original thumb-map)]
+          (let [thumb-params (webp-override (mime-type-of (or local-original "")) thumb-map)] ;; can we use mime-type of original (not original local)?
             (when-let [thumb (original->thumbnail local-original thumb-params)]
               (perf/publish {:generate-thumbail 1})
               (background-check-and-delete-original

--- a/test/vignette/http/route_helpers_test.clj
+++ b/test/vignette/http/route_helpers_test.clj
@@ -41,28 +41,30 @@
          (error-response 404 ..params..) => ..error..))
 
 (facts :handle-original
-       (handle-original ..store.. original-image-params ..request..) => ..response..
-       (provided
-         (sp/get-thumbnail ..store.. original-forced-image-params) => nil
-         (sp/get-original ..store.. original-forced-image-params) => ..original..
-         (sp/filename ..original..) => ..filename..
-         (mime-type-of ..filename..) => ..mime_type..
-         (u/is-passthrough-required ..mime_type.. original-forced-image-params) => true
-         (create-image-response ..original.. {}) => ..response..
-         )
+  (let [original-image-params {}
+        original-forced-image-params {:request-type :thumbnail, :thumbnail-mode "type-convert"}]
+    (handle-original ..store.. original-image-params ..request..) => ..response..
+    (provided
+      (sp/get-thumbnail ..store.. original-forced-image-params) => nil
+      (sp/get-original ..store.. original-forced-image-params) => ..original..
+      (sp/filename ..original..) => ..filename..
+      (mime-type-of ..filename..) => ..mime_type..
+      (u/is-passthrough-required ..mime_type.. original-forced-image-params) => true
+      (create-image-response ..original.. {}) => ..response..
+      )
 
-       (handle-original ..store.. original-image-params ..request..) => ..error..
-       (provided
-         (u/get-or-generate-thumbnail ..store.. original-forced-image-params) => nil
-         (error-response 404 original-image-params) => ..error..)
+    (handle-original ..store.. original-image-params ..request..) => ..error..
+    (provided
+      (u/get-or-generate-thumbnail ..store.. original-forced-image-params) => nil
+      (error-response 404 original-image-params) => ..error..)
 
-       (try+
-         (handle-original ..store.. original-image-params ..request..)
-         (catch [:type :convert-error] e
-           (:response-code e))) => 404
-       (provided
-         (sp/get-thumbnail ..store.. original-forced-image-params) => nil
-         (sp/get-original ..store.. original-forced-image-params) => nil))
+    (try+
+      (handle-original ..store.. original-image-params ..request..)
+      (catch [:type :convert-error] e
+             (:response-code e))) => 404
+    (provided
+      (sp/get-thumbnail ..store.. original-forced-image-params) => nil
+      (sp/get-original ..store.. original-forced-image-params) => nil)))
 
 (facts :route-params->image-type
        (route-params->image-type {:image-type ""}) => "images"

--- a/test/vignette/http/route_helpers_test.clj
+++ b/test/vignette/http/route_helpers_test.clj
@@ -4,6 +4,7 @@
             [midje.sweet :refer :all]
             [pantomime.mime :refer [mime-type-of]]
             [ring.mock.request :refer :all]
+            [slingshot.slingshot :refer [try+]]
             [vignette.http.route-helpers :refer :all]
             [vignette.protocols :refer :all]
             [vignette.util.image-response :refer :all]
@@ -50,7 +51,15 @@
          (create-image-response ..original.. {}) => ..response..
          )
 
-       (handle-original ..store.. original-image-params ..request..) => (throws Exception)
+       (handle-original ..store.. original-image-params ..request..) => ..error..
+       (provided
+         (u/get-or-generate-thumbnail ..store.. original-forced-image-params) => nil
+         (error-response 404 original-image-params) => ..error..)
+
+       (try+
+         (handle-original ..store.. original-image-params ..request..)
+         (catch [:type :convert-error] e
+           (:response-code e))) => 404
        (provided
          (sp/get-thumbnail ..store.. original-forced-image-params) => nil
          (sp/get-original ..store.. original-forced-image-params) => nil))

--- a/test/vignette/http/routes_test.clj
+++ b/test/vignette/http/routes_test.clj
@@ -132,18 +132,24 @@
                       :revision "12345"
                       :wikia "lotr"
                       :requested-format nil
-                      :options {}} ]
+                      :options {}}
+        forced-route-params (assoc route-params :thumbnail-mode "type-convert" :request-type :thumbnail)]
     ((create-routes (image-routes {:wikia-store ..wiki-store.. :static-store ..static-store..})) (request :get "/lotr/3/35/ropes.jpg/revision/12345")) => (contains {:status 200})
     (provided
-     (sp/get-original ..wiki-store.. route-params) => (ls/create-stored-object (io/file "image-samples/ropes.jpg")))
+     (sp/get-thumbnail ..wiki-store.. forced-route-params) => nil
+     (sp/get-original ..wiki-store.. forced-route-params) => (ls/create-stored-object (io/file "image-samples/ropes.jpg")))
 
     ((create-routes (image-routes {:wikia-store ..wiki-store.. :static-store ..static-store..})) (request :get "/lotr/3/35/ropes.jpg/revision/12345")) => (contains {:status 404})
     (provided
-     (sp/get-original ..wiki-store.. route-params) => nil)
+     (sp/get-thumbnail ..wiki-store.. forced-route-params) => nil
+     (sp/get-original ..wiki-store.. forced-route-params) => nil
+     (ir/error-image forced-route-params) => ..thumb..
+     (ir/create-image-response ..thumb.. forced-route-params) => {})
 
     ((create-routes (image-routes {:wikia-store ..wiki-store.. :static-store ..static-store..})) (request :get "/lotr/3/35/ropes.jpg/revision/12345")) => (contains {:status 500})
     (provided
-      (sp/get-original ..wiki-store.. route-params) =throws=> (NullPointerException.))))
+      (sp/get-thumbnail ..wiki-store.. forced-route-params) =throws=> (NullPointerException.)
+    )))
 
 (facts :window-crop-route
        (in-wiki-context-route-matches proto/window-crop-route

--- a/test/vignette/util/thumbnail_test.clj
+++ b/test/vignette/util/thumbnail_test.clj
@@ -67,10 +67,11 @@
          (get-original ..store.. beach-map) => ..original..
          (original->local ..original..) => ..local..
          (filename ..original..) => ..filename..
-         (is-passthrough-required ..filename..) => false
+         (is-passthrough-required ..original-mime-type.. beach-map) => false
          (original->thumbnail ..local.. beach-map) => ..thumb..
          (background-check-and-delete-original beach-map & anything) => nil
-         (create-stored-object ..thumb.. & anything) => ..object..)
+         (create-stored-object ..thumb.. & anything) => ..object..
+         (mime-type-of ..filename..) => ..original-mime-type..)
 
        (generate-thumbnail ..store.. beach-map nil) => (throws ExceptionInfo)
        (provided
@@ -81,8 +82,9 @@
          (get-original ..store.. beach-map) => ..original..
          (original->local ..original..) => ..local..
          (filename ..original..) => ..filename..
-         (is-passthrough-required ..filename..) => false
-         (original->thumbnail ..local.. beach-map) => nil))
+         (is-passthrough-required ..original-mime-type.. beach-map) => false
+         (original->thumbnail ..local.. beach-map) => nil
+         (mime-type-of ..filename..) => ..original-mime-type..))
 
 (facts :get-or-generate-thumbnail
        ; get existing
@@ -114,7 +116,11 @@
                                                        "--mode" "thumbnail"] :in-any-order))
 
 (facts :passthrough-mime-types
-       (is-passthrough-required nil) => false
-       (is-passthrough-required "") => false
-       (is-passthrough-required "file.jpg") => false
-       (is-passthrough-required "file.ogv") => true)
+       (is-passthrough-required "image/png" {}) => false
+       (is-passthrough-required "image/jpeg" {}) => false
+       (is-passthrough-required "audio/ogg" {}) => true
+       (is-passthrough-required "video/ogg" {}) => true
+       (is-passthrough-required "image/png" {:thumbnail-mode "type-convert" :options {}}) => true
+       (is-passthrough-required "image/png" {:thumbnail-mode "type-convert" :options {:format nil}}) => true
+       (is-passthrough-required "image/png" {:thumbnail-mode "type-convert" :options {:format "webp"}}) => false
+       (is-passthrough-required "image/bmp" {:thumbnail-mode "type-convert" :options {:format "webp"}}) => true)


### PR DESCRIPTION
This removes some of the duplicated checks. Also optimizes the performance for full size images, as previously we were downloading the originals regardless if the converted `webp` version was available in s3 cache.
