### PR TITLE
PLATFORM-2894: Setting quality for converting PNGs into WebP to 90

### DIFF
--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -38,6 +38,9 @@ CONVERT_CONSTRAINTS=${CONVERT_CONSTRAINTS:-" -limit memory 256MB -limit map 256M
 # with phpthumb
 JPEG_QUALITY_LEVEL=80
 
+# When presenting PNG's using WebP we should use higher quality to avoid artifacts
+WEBP_PNG_QUALITY_LEVEL=90
+
 MODE_OPTIONS=(
 	"fixed-aspect-ratio"
 	"fixed-aspect-ratio-down"
@@ -276,6 +279,14 @@ function original_is() {
 	fi
 }
 
+function target_webp() {
+    if [[ "$1" =~ ^webp: ]]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
 function remove_custom_type() {
 	OUT=${OUT#*:}
 }
@@ -342,11 +353,22 @@ function thumb_params() {
 			HEIGHT=${WIDTH}
 	fi
 
-	original_is $TYPE_JPEG
+	original_is ${TYPE_JPEG}
 	jpeg=$?
 
+	original_is ${TYPE_PNG}
+	png=$?
+
+	target_webp ${OUT}
+	webp=$?
+
+
 	if [[ $jpeg -eq 1 ]]; then
-			QUALITY="-quality ${JPEG_QUALITY_LEVEL}"
+		QUALITY="-quality ${JPEG_QUALITY_LEVEL}"
+	fi
+
+	if [[ $png -eq 1 ]] && [[ $webp -eq 1 ]]; then
+	    QUALITY="-quality ${WEBP_PNG_QUALITY_LEVEL}"
 	fi
 
 	# fixed-aspect-ratio (was LS, read fixed-aspect-ratio): thumbnail using a fixed aspect ratio and fill to generate a thumbnail with the exact dimensions given; no upscaling.

--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -36,7 +36,11 @@ CONVERT_CONSTRAINTS=${CONVERT_CONSTRAINTS:-" -limit memory 256MB -limit map 256M
 # sacrificing too much image quality. in the tests that were done, this
 # produced images that were closer in size to what is currently being created
 # with phpthumb
+# JPEG_QUALITY_LEVEL quality is used when generating JPEG thumbnails
 JPEG_QUALITY_LEVEL=80
+
+# Quality used for generating WebP images from JPEG
+WEBP_JPEG_QUALITY_LEVEL=85
 
 # When presenting PNG's using WebP we should use higher quality to avoid artifacts
 WEBP_PNG_QUALITY_LEVEL=90
@@ -364,7 +368,11 @@ function thumb_params() {
 
 
 	if [[ $jpeg -eq 1 ]]; then
-		QUALITY="-quality ${JPEG_QUALITY_LEVEL}"
+		if [[ $webp -eq 1 ]]; then
+			QUALITY="-quality ${WEBP_JPEG_QUALITY_LEVEL}"
+		else
+			QUALITY="-quality ${JPEG_QUALITY_LEVEL}"
+		fi
 	fi
 
 	if [[ $png -eq 1 ]] && [[ $webp -eq 1 ]]; then

--- a/test/vignette/http/integration_test.clj
+++ b/test/vignette/http/integration_test.clj
@@ -128,7 +128,7 @@
       (:status response) => 200
       (get (:headers response) "Surrogate-Key") => "6f13d7df6b332e4945d90bd6785226b535f8b248"
       (get (:headers response) "Content-Disposition") => "inline; filename=\"beach.webp\"; filename*=UTF-8''beach.webp"
-      (Integer/parseInt (get (:headers response) "Content-Length")) => (roughly 11598 50)
+      (Integer/parseInt (get (:headers response) "Content-Length")) => (roughly 14050 50)
       (get (:headers response) "Connection") => "close"
       (get (:headers response) "Cache-Control") => "public, max-age=31536000"
       (get (:headers response) "Content-Type") => "image/webp"


### PR DESCRIPTION
For now we will just use quality level 90 for PNGs being converted to WebP and see if we get better results.

ping: @Wikia/core-platform-team