### PR TITLE
PLATFORM-2920: Detect original image content type base on content, not on extension

### DIFF
--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -103,12 +103,12 @@
   The original will be removed after the thumbnailing is completed."
   [store thumb-map original]
   (if-let [original (or original (get-original store thumb-map))]
-    (let [original-mime-type (mime-type-of (or (filename original) ""))]
-      (if (is-passthrough-required original-mime-type thumb-map)
+    (let [original-content-type (content-type original)]
+      (if (is-passthrough-required original-content-type thumb-map)
           original
           (when-let [local-original (original->local original)]
             (try+
-              (let [thumb-params (webp-override original-mime-type thumb-map)]
+              (let [thumb-params (webp-override original-content-type thumb-map)]
                 (when-let [thumb (original->thumbnail local-original thumb-params)]
                   (perf/publish {:generate-thumbail 1})
                   (background-check-and-delete-original

--- a/test/vignette/http/route_helpers_test.clj
+++ b/test/vignette/http/route_helpers_test.clj
@@ -47,8 +47,7 @@
     (provided
       (sp/get-thumbnail ..store.. original-forced-image-params) => nil
       (sp/get-original ..store.. original-forced-image-params) => ..original..
-      (sp/filename ..original..) => ..filename..
-      (mime-type-of ..filename..) => ..mime_type..
+      (sp/content-type ..original..) => ..mime_type..
       (u/is-passthrough-required ..mime_type.. original-forced-image-params) => true
       (create-image-response ..original.. {}) => ..response..
       )

--- a/test/vignette/util/thumbnail_test.clj
+++ b/test/vignette/util/thumbnail_test.clj
@@ -36,7 +36,7 @@
        (generate-thumbnail ..store.. beach-map nil) => ..file..
        (provided
          (get-original ..store.. beach-map) => ..file..
-         (filename ..file..) => "file.ogv"))
+         (content-type ..file..) => "video/ogg"))
 
 (facts :orignal->local-maintains-file-extension
        (.getName (original->local
@@ -66,12 +66,11 @@
        (provided
          (get-original ..store.. beach-map) => ..original..
          (original->local ..original..) => ..local..
-         (filename ..original..) => ..filename..
+         (content-type ..original..) => ..original-mime-type..
          (is-passthrough-required ..original-mime-type.. beach-map) => false
          (original->thumbnail ..local.. beach-map) => ..thumb..
          (background-check-and-delete-original beach-map & anything) => nil
-         (create-stored-object ..thumb.. & anything) => ..object..
-         (mime-type-of ..filename..) => ..original-mime-type..)
+         (create-stored-object ..thumb.. & anything) => ..object..)
 
        (generate-thumbnail ..store.. beach-map nil) => (throws ExceptionInfo)
        (provided
@@ -81,10 +80,9 @@
        (provided
          (get-original ..store.. beach-map) => ..original..
          (original->local ..original..) => ..local..
-         (filename ..original..) => ..filename..
+         (content-type ..original..) => ..original-mime-type..
          (is-passthrough-required ..original-mime-type.. beach-map) => false
-         (original->thumbnail ..local.. beach-map) => nil
-         (mime-type-of ..filename..) => ..original-mime-type..))
+         (original->thumbnail ..local.. beach-map) => nil))
 
 (facts :get-or-generate-thumbnail
        ; get existing


### PR DESCRIPTION
Some of the jpg&png files are stored without an extension. When generating thumbnails, use the actual content type to make a decision about serving webp.