### PR TITLE
PLATFORM-2995: fixing SVG images

### DIFF
--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -159,7 +159,6 @@ while true; do
 		--in)
 			shift
 			IN=$1
-			echo "??? ${IN}"
 			;;
 		--out)
 			shift

--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -548,18 +548,18 @@ function thumb() {
 	target_webp ${OUT}
 	webp=$?
 
-	if [[ $gif -eq 1 && $animated -eq 1 && $STILL -ne 1 ]]; then
-		animated_thumb_params
-	else
-		thumb_params 
-	fi
-
 	original_is $TYPE_SVG
 	svg=$?
 
 	if [[ $svg -eq 1 ]]; then
 		set_custom_type $TYPE_PNG
 		svg_preoptions
+	fi
+
+	if [[ $gif -eq 1 && $animated -eq 1 && $STILL -ne 1 ]]; then
+		animated_thumb_params
+	else
+		thumb_params
 	fi
 
 	if [[ $animated -eq 1 && $STILL -eq 1 ]]; then

--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -159,6 +159,7 @@ while true; do
 		--in)
 			shift
 			IN=$1
+			echo "??? ${IN}"
 			;;
 		--out)
 			shift
@@ -529,13 +530,20 @@ function svg_preoptions() {
 	local orig_height=$($IDENTIFY -format "%h\n" "$IN" | head -1)
 	local orig_width=$($IDENTIFY -format "%w\n" "$IN" | head -1)
 
-	if [[ ${orig_width} -gt ${WIDTH} || ${orig_height} -gt ${HEIGHT} ]]; then
-		THUMB_PRE_OPTIONS="-background none"
-	else
-		local width_density=`echo "(1.5 * ${WIDTH}) / (${orig_width} / ${default_density})" | bc -l`
-		local height_density=`echo "(1.5 * ${HEIGHT}) / (${orig_height} / ${default_density})" | bc -l`
+	THUMB_PRE_OPTIONS="-background none"
 
-		THUMB_PRE_OPTIONS="-background none -density ${width_density}x${height_density}"
+	if [ "${HEIGHT}" == ":auto" ]; then
+		 if [[ ${orig_width} -le ${WIDTH} ]]; then
+			local width_density=`echo "(1.5 * ${WIDTH}) / (${orig_width} / ${default_density})" | bc -l`
+			THUMB_PRE_OPTIONS="-background none -density ${width_density}"
+		fi
+	else
+		if [[ ${orig_width} -le ${WIDTH} || ${orig_height} -le ${HEIGHT} ]]; then
+			local width_density=`echo "(1.5 * ${WIDTH}) / (${orig_width} / ${default_density})" | bc -l`
+			local height_density=`echo "(1.5 * ${HEIGHT}) / (${orig_height} / ${default_density})" | bc -l`
+
+			THUMB_PRE_OPTIONS="-background none -density ${width_density}x${height_density}"
+		fi
 	fi
 }
 

--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -536,13 +536,11 @@ function svg_preoptions() {
 			local width_density=`echo "(1.5 * ${WIDTH}) / (${orig_width} / ${default_density})" | bc -l`
 			THUMB_PRE_OPTIONS="-background none -density ${width_density}"
 		fi
-	else
-		if [[ ${orig_width} -le ${WIDTH} || ${orig_height} -le ${HEIGHT} ]]; then
-			local width_density=`echo "(1.5 * ${WIDTH}) / (${orig_width} / ${default_density})" | bc -l`
-			local height_density=`echo "(1.5 * ${HEIGHT}) / (${orig_height} / ${default_density})" | bc -l`
+	elif [[ ${orig_width} -le ${WIDTH} || ${orig_height} -le ${HEIGHT} ]]; then
+		local width_density=`echo "(1.5 * ${WIDTH}) / (${orig_width} / ${default_density})" | bc -l`
+		local height_density=`echo "(1.5 * ${HEIGHT}) / (${orig_height} / ${default_density})" | bc -l`
 
-			THUMB_PRE_OPTIONS="-background none -density ${width_density}x${height_density}"
-		fi
+		THUMB_PRE_OPTIONS="-background none -density ${width_density}x${height_density}"
 	fi
 }
 


### PR DESCRIPTION
*WORK IN PROGRESS*

Fixes:
* `svg_preoptions` has to be called before `thumb_params`, because for some modes `thumb_params` removes the `$IN` variable, which is needed by `svg_preoptions`
* if `$HEIGHT` is set to `":auto"`, we cannot use it as integer when calculating SVG density

Sample url that will be fixed by this PR: http://vignette3.wikia.nocookie.net/logopedia/images/thumb/2/2e/Seven_logo.svg/125px-0%2C379%2C0%2C395-Seven_logo.svg
