### PR TITLE
PLATFORM-2995: Log slow thumbnailer runs

### DIFF
--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -56,15 +56,15 @@
 
 (defn run-thumbnailer
   ([args thumb-map]
-  (let [start-ms (System/currentTimeMillis)
-        result (perf/timing :imagemagick (apply sh args))
-        end-ms (System/currentTimeMillis)]
-    (if (> (- end-ms start-ms) 5000)
-        (do
-          (log/info "slow-thumbnailer-call" {:time_ms (- end-ms start-ms) :thumb_map thumb-map})
+    (let [start-ms (System/currentTimeMillis)
+          result (perf/timing :imagemagick (apply sh args))
+          elapsed-ms (- System/currentTimeMillis start-ms)]
+      (if (> elapsed-ms 5000)
+          (do
+            (log/info "slow-thumbnailer-call" {:time_ms elapsed-ms :thumb_map thumb-map})
+            result)
           result)
-        result)
-    ))
+      ))
   ([args]
     (run-thumbnailer args {})))
 

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -55,8 +55,18 @@
           thumb-map))
 
 (defn run-thumbnailer
-  [args]
-  (perf/timing :imagemagick (apply sh args)))
+  ([args thumb-map]
+  (let [start-ms (System/currentTimeMillis)
+        result (perf/timing :imagemagick (apply sh args))
+        end-ms (System/currentTimeMillis)]
+    (if (> (- end-ms start-ms) 5000)
+        (do
+          (log/info "slow-thumbnailer-call" {:time_ms (- end-ms start-ms) :thumb_map thumb-map})
+          result)
+        result)
+    ))
+  ([args]
+    (run-thumbnailer args {})))
 
 (defn original->thumbnail
   [resource thumb-map]

--- a/src/vignette/util/thumbnail.clj
+++ b/src/vignette/util/thumbnail.clj
@@ -58,7 +58,7 @@
   ([args thumb-map]
     (let [start-ms (System/currentTimeMillis)
           result (perf/timing :imagemagick (apply sh args))
-          elapsed-ms (- System/currentTimeMillis start-ms)]
+          elapsed-ms (- (System/currentTimeMillis) start-ms)]
       (if (> elapsed-ms 5000)
           (do
             (log/info "slow-thumbnailer-call" {:time_ms elapsed-ms :thumb_map thumb-map})


### PR DESCRIPTION
If thumbnailer script runs for longer than 5 seconds, log the thumbnailing details so we can investigate performance issues with some of the images