### PR TITLE
Higher memory limit (performance boosts)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: lein
 jdk:
   - oraclejdk8
 env:
@@ -29,4 +29,4 @@ script:
   - magick --version
   - convert --version | grep webp
   - gif2webp -version
-  - lein2 midje
+  - lein midje

--- a/bin/thumbnail
+++ b/bin/thumbnail
@@ -31,7 +31,7 @@ GETOPT=${GETOPT:-"/usr/bin/getopt"}
 # Then 
 # $ export CONVERT_CONSTRAINTS=" "
 # The options below result in a segfault on OS X.
-CONVERT_CONSTRAINTS=${CONVERT_CONSTRAINTS:-" -limit memory 256MB -limit map 256MB -limit disk 1024MB -limit thread 2 -limit time 60 "}
+CONVERT_CONSTRAINTS=${CONVERT_CONSTRAINTS:-" -limit memory 768MB -limit map 768MB -limit disk 1024MB -limit thread 2 -limit time 60 "}
 
 # dial down the quality level. this should save us some space without
 # sacrificing too much image quality. in the tests that were done, this


### PR DESCRIPTION
Test animated gif - `s3://dragonsdogma/images/7/7c/Skill_Magick_Archer_Magick_Rebalancer.gif`

With old settings:
```
➜  gif_test time /opt/imagemagick-7.0.5/bin/convert test.gif -limit memory 256MB -limit map 256MB -limit disk 1024MB -limit thread 2 -limit time 120 -auto-orient -coalesce -thumbnail 670x375^ -gravity center -background none -extent 670x375 -layers Optimize test-7.0.5.gif
convert: DistributedPixelCache '127.0.0.1' @ error/distribute-cache.c/ConnectPixelCacheServer/242.
convert: cache resources exhausted `test.gif' @ error/cache.c/OpenPixelCache/3631.
convert: DistributedPixelCache '127.0.0.1' @ error/distribute-cache.c/ConnectPixelCacheServer/242.
convert: cache resources exhausted `test.gif' @ error/cache.c/OpenPixelCache/3631.
convert: DistributedPixelCache '127.0.0.1' @ error/distribute-cache.c/ConnectPixelCacheServer/242.
convert: cache resources exhausted `test.gif' @ error/cache.c/OpenPixelCache/3631.
convert: DistributedPixelCache '127.0.0.1' @ error/distribute-cache.c/ConnectPixelCacheServer/242.
convert: cache resources exhausted `test.gif' @ error/cache.c/OpenPixelCache/3631.
convert: DistributedPixelCache '127.0.0.1' @ error/distribute-cache.c/ConnectPixelCacheServer/242.
convert: cache resources exhausted `test.gif' @ error/cache.c/OpenPixelCache/3631.
convert: DistributedPixelCache '127.0.0.1' @ error/distribute-cache.c/ConnectPixelCacheServer/242.
convert: cache resources exhausted `test.gif' @ error/cache.c/OpenPixelCache/3631.
/opt/imagemagick-7.0.5/bin/convert test.gif -limit memory 256MB -limit map     48.89s user 23.22s system 116% cpu 1:01.80 total
```

With new settings:
```
➜  gif_test time /opt/imagemagick-7.0.5/bin/convert test.gif -limit memory 768MB -limit map 768MB -limit disk 1024MB -limit thread 2 -limit time 120 -auto-orient -coalesce -thumbnail 670x375^ -gravity center -background none -extent 670x375 -layers optimize test-7.0.5.gif
/opt/imagemagick-7.0.5/bin/convert test.gif -limit memory 512MB -limit map     44.42s user 4.08s system 134% cpu 35.995 total
```

I would also recommend to switch ImageMagick for animated GIFs to `gifsicle`
```
➜  gif_test time gifsicle test.gif --resize 670x375 -O > gifsicle.gif
gifsicle test.gif --resize 670x375 -O > gifsicle.gif  1.23s user 0.09s system 99% cpu 1.330 total
```
Smaller size + significantly better performance.