### PR TITLE
OPS-12119: X-Surrogate-Key header cleanup

### DIFF
--- a/src/vignette/util/image_response.clj
+++ b/src/vignette/util/image_response.clj
@@ -108,8 +108,7 @@
         (:uuid image-map))
     (let [sk (surrogate-key image-map)]
       (-> response-map
-          (header "Surrogate-Key" sk)
-          (header "X-Surrogate-Key" sk)))
+          (header "Surrogate-Key" sk)))
     response-map))
 
 (defn surrogate-key

--- a/test/vignette/util/image_response_test.clj
+++ b/test/vignette/util/image_response_test.clj
@@ -42,10 +42,9 @@
        (when-header-val {} "Content-Type" "type") => {:headers {"Content-Type" "type"}})
 
 (facts :add-surrogate-key-header
-       (add-surrogate-header {} {:uuid "123"}) => {:headers {"Surrogate-Key" "123", "X-Surrogate-Key" "123"}}
+       (add-surrogate-header {} {:uuid "123"}) => {:headers {"Surrogate-Key" "123"}}
        (add-surrogate-header {} {:wikia "wikia" :original "orig" :image-type "images"}) =>
-       {:headers {"Surrogate-Key"   "c8dfba77e9beb5c26ca20d4411674065d4a0ded5"
-                  "X-Surrogate-Key" "c8dfba77e9beb5c26ca20d4411674065d4a0ded5"}})
+       {:headers {"Surrogate-Key"   "c8dfba77e9beb5c26ca20d4411674065d4a0ded5"}})
 
 (facts :add-vary-header
        (add-vary-header {} {:requested-format nil :request-type :thumbnail } "image/png") => {:headers {"Vary" "Accept"}}


### PR DESCRIPTION
`X-Surrogate-Key` - Fastly doesn't support such header (they use `Surrogate-Key`. We want to cleanup this custom header (it's not used by our caches).